### PR TITLE
Added world quest "holiday" reminders

### DIFF
--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -71,6 +71,7 @@ local GetSubZoneText = GetSubZoneText
 local GetContainerItemID = GetContainerItemID
 local RequestRaidInfo = RequestRaidInfo
 local RequestLFDPlayerLockInfo = RequestLFDPlayerLockInfo
+local IsWorldQuestActive = C_TaskQuest.IsActive
 
 -- Addon APIs
 local FormatTime = Rarity.Utils.PrettyPrint.FormatTime

--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -1440,8 +1440,10 @@ local function addGroup(group, requiresGroup)
 									numHolidayReminders = numHolidayReminders + 1
 									if numHolidayReminders <= 2 then
 										local text
-										if IsWorldQuestActive(v.worldQuestId) then
-											text = format(L["A world event is currently available for %s! Go get it!"], itemLink or itemName or v.name)
+										if v.worldQuestId then
+											if IsWorldQuestActive(v.worldQuestId) then
+												text = format(L["A world event is currently available for %s! Go get it!"], itemLink or itemName or v.name)
+											end
 										else
 											text = format(L["A holiday event is available today for %s! Go get it!"], itemLink or itemName or v.name)
 										end

--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -1292,6 +1292,12 @@ local function addGroup(group, requiresGroup)
 									status = colorize(L["Undefeated"], green)
 								end
 							end
+							-- If item is linked to a World Quest, flag as unavailable if WQ isn't up.
+							if v.worldQuestId then
+								if IsWorldQuestActive(v.worldQuestId) == false then
+									status = colorize(L["Unavailable"], gray)
+								end
+							end
 						elseif v.questId and v.holidayTexture then
 							if Rarity.holiday_textures[v.holidayTexture] == nil then
 								status = colorize(L["Unavailable"], gray)

--- a/Core/GUI.lua
+++ b/Core/GUI.lua
@@ -1433,14 +1433,18 @@ local function addGroup(group, requiresGroup)
 								-- Holiday reminder
 								if
 									Rarity.db.profile.holidayReminder and Rarity.allRemindersDone == nil and v.holidayReminder ~= false and
-										v.cat == HOLIDAY and
+										(v.cat == HOLIDAY or v.worldQuestId) and
 										status == colorize(L["Undefeated"], green)
 								 then
 									Rarity.anyReminderDone = true
 									numHolidayReminders = numHolidayReminders + 1
 									if numHolidayReminders <= 2 then
-										local text =
-											format(L["A holiday event is available today for %s! Go get it!"], itemLink or itemName or v.name)
+										local text
+										if IsWorldQuestActive(v.worldQuestId) then
+											text = format(L["A world event is currently available for %s! Go get it!"], itemLink or itemName or v.name)
+										else
+											text = format(L["A holiday event is available today for %s! Go get it!"], itemLink or itemName or v.name)
+										end
 										Rarity:Print(text)
 										if tostring(SHOW_COMBAT_TEXT) ~= "0" then
 											if type(CombatText_AddMessage) == "nil" then

--- a/DB/Mounts/BattleForAzeroth.lua
+++ b/DB/Mounts/BattleForAzeroth.lua
@@ -517,6 +517,7 @@ local bfaMounts = {
 		groupSize = 3,
 		equalOdds = true,
 		questId = {53000},
+		worldQuestId = 52196,
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.VOLDUN, x = 44.6, y = 56.2, n = L["Dunegorger Kraulok"]}
 		}

--- a/Locales.lua
+++ b/Locales.lua
@@ -1794,6 +1794,7 @@ L["Bottle of Gloop"] = true
 L["Piccolo of the Flaming Fire"] = true
 L["Lucy's Lost Collar"] = true
 L["Dirty Glinting Object"] = true
+L["A world event is currently available for %s! Go get it!"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -2526,7 +2526,7 @@ function R:CreateGroup(options, group, isUser)
 						self:Update("OPTIONS")
 					end,
 					hidden = function()
-						return item.cat ~= HOLIDAY or (item.questId == nil and item.lockDungeonId == nil and item.holidayTexture == nil)
+						return (item.cat ~= HOLIDAY and item.worldQuestId == nil) or (item.questId == nil and item.lockDungeonId == nil and item.holidayTexture == nil)
 					end
 				},
 				spacer3 = {type = "header", name = L["Defeat Detection"], order = newOrder()},

--- a/Utils/DatabaseMaintenanceHelper.lua
+++ b/Utils/DatabaseMaintenanceHelper.lua
@@ -51,6 +51,7 @@ local DBH = {
 			lockoutDetails = false,
 			instanceDifficulties = false,
 			unique = false,
+			worldQuestId = false,
 			-- Populated fields (SavedVariables)
 			attempts = false,
 			lastAttempts = false,


### PR DESCRIPTION
In regards to the issue #203, I have added an option to check if any given world quest is currently active. This is then integrated into the existing holiday reminders, as a way of notifying players when certain items are obtainable. By flagging any relevant items with 'worldQuestId', the reminder should function just like the holiday ones, just with a different display text. If the linked world quest is not active, the item is marked as "Unavailable", and thus can also be hidden from the GUI if the option to hide unavailable items is checked. The option to enable/disable reminders on a specific item is also added on these items with 'worldQuestId'.

Currently I have only implemented the feature on one item; the Slightly Damp Pile of Fur from Dunegorger Kraulok (World boss in Vol'dun). Luckily enough this guy is live this week, so that opens up a window for proper testing without fake ids. The idea is that this can further be implemented on other items such as those tied to Assaults in Uldum and Vale of Eternal Blossom, and possibly others.

I'm uploading this as a draft, as I would appreciate a second glance. Or just feedback in general.


Couple things I haven't gotten around to yet:
- Are the world quest id's the same for Alliance and Horde?
- Need for multiple WQ Id's on a singular item? Ref. above
- What if player hasn't unlocked world quests in that general area?
- - Can items still even drop?
- - Does it matter for the API call?
- Does the API still return the WQ as active after it has been completed? Could affect the Assaults