### PR TITLE
Added missing items from Winter's Veil gifts + fixed couple old ones

### DIFF
--- a/DB/Pets/HolidayEvents.lua
+++ b/DB/Pets/HolidayEvents.lua
@@ -15,7 +15,6 @@ local holidayEventPets = {
 		chance = 50,
 		creatureId = 24968,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 87, x = 33.2, y = 67.8}, {m = 25, x = 42.4, y = 41}, {m = 86, x = 54.4, y = 77}}
 	},
@@ -130,7 +129,6 @@ local holidayEventPets = {
 		chance = 50,
 		creatureId = 55215,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 87, x = 33.2, y = 67.8}, {m = 25, x = 42.4, y = 41}, {m = 86, x = 54.4, y = 77}}
 	},
@@ -145,7 +143,6 @@ local holidayEventPets = {
 		chance = 100,
 		creatureId = 73741,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 87, x = 33.2, y = 67.8}, {m = 25, x = 42.4, y = 41}, {m = 86, x = 54.4, y = 77}}
 	},

--- a/DB/Pets/HolidayEvents.lua
+++ b/DB/Pets/HolidayEvents.lua
@@ -15,6 +15,7 @@ local holidayEventPets = {
 		chance = 50,
 		creatureId = 24968,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 87, x = 33.2, y = 67.8}, {m = 25, x = 42.4, y = 41}, {m = 86, x = 54.4, y = 77}}
 	},
@@ -129,6 +130,7 @@ local holidayEventPets = {
 		chance = 50,
 		creatureId = 55215,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 87, x = 33.2, y = 67.8}, {m = 25, x = 42.4, y = 41}, {m = 86, x = 54.4, y = 77}}
 	},
@@ -143,6 +145,7 @@ local holidayEventPets = {
 		chance = 100,
 		creatureId = 73741,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 87, x = 33.2, y = 67.8}, {m = 25, x = 42.4, y = 41}, {m = 86, x = 54.4, y = 77}}
 	},

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -341,6 +341,18 @@ local holidayEventToys = {
 		questId = {6983, 7043},
 		requiresAlliance = true
 	},
+	["Wild Holly"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Wild Holly"],
+		itemId = 172219,
+		items = {116762},
+		chance = 100, -- Blind guess
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		questId = {6983, 7043}
+	},
 	["Zhevra Lounge Cushion"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
 		type = CONSTANTS.ITEM_TYPES.ITEM,

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -405,6 +405,18 @@ local holidayEventToys = {
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
 		questId = {6983, 7043}
 	},
+	["Wreath-A-Rang"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Wreath-A-Rang"],
+		itemId = 178530,
+		items = {116762},
+		chance = 100, -- Blind guess
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		questId = {6983, 7043}
+	},
 	["Zhevra Lounge Cushion"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
 		type = CONSTANTS.ITEM_TYPES.ITEM,

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -146,6 +146,32 @@ local holidayEventToys = {
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
 		questId = {6983, 7043}
 	},
+	["Hearthstation (Horde)"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Hearthstation"],
+		itemId = 151344,
+		items = {116762},
+		chance = 100, -- Blind guess
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		questId = {6983, 7043},
+		requiresHorde = true
+	},
+	["Hearthstation (Alliance)"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Hearthstation"],
+		itemId = 151343,
+		items = {116762},
+		chance = 100, -- Blind guess
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		questId = {6983, 7043},
+		requiresAlliance = true
+	},
 	["MiniZep Controller"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
 		type = CONSTANTS.ITEM_TYPES.ITEM,

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -69,6 +69,19 @@ local holidayEventToys = {
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
+	["Crashin' Thrashin' Juggernaught"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Crashin' Thrashin' Juggernaught"],
+		itemId = 172222,
+		items = {116762},
+		chance = 100, -- Blind guess
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		questId = {6983, 7043},
+		requiresHorde = true
+	},
 	["Crashin' Thrashin' Racer Controller"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
 		type = CONSTANTS.ITEM_TYPES.ITEM,

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -40,6 +40,7 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -53,6 +54,7 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -66,6 +68,7 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -79,6 +82,7 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -95,7 +99,7 @@ local holidayEventToys = {
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
-	["Foot Ball"] = {
+	["Foot Ball"] = {		-- WHY is this item here? It can be purchased from vendor
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
 		type = CONSTANTS.ITEM_TYPES.ITEM,
 		isToy = true,
@@ -105,6 +109,7 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -185,6 +190,7 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -267,6 +273,7 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -134,6 +134,18 @@ local holidayEventToys = {
 		questId = {8788, 8767},
 		coords = {{m = 86, x = 49.1, y = 78.2, h = true}, {m = 87, x = 33.4, y = 65.9, a = true}}
 	},
+	["Greatfather Winter's Hearthstone"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Greatfather Winter's Hearthstone"],
+		itemId = 162973,
+		items = {116762},
+		chance = 100, -- Blind guess
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		questId = {6983, 7043}
+	},
 	["MiniZep Controller"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
 		type = CONSTANTS.ITEM_TYPES.ITEM,

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -235,6 +235,19 @@ local holidayEventToys = {
 		christmasOnly = true,
 		coords = {{m = 86, x = 49.1, y = 78.2, h = true}, {m = 87, x = 33.4, y = 65.9, a = true}}
 	},
+	["Scroll of Storytelling"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Scroll of Storytelling"],
+		itemId = 116456,
+		items = {116762},
+		chance = 8,
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
+		questId = {6983, 7043}
+	},
 	["Silver-Plated Turkey Shooter"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
 		type = CONSTANTS.ITEM_TYPES.ITEM,

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -30,6 +30,19 @@ local holidayEventToys = {
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.HALLOWS_END,
 		coords = {{m = 104, x = 40.6, y = 79.4}}
 	},
+	["Crashin' Thrashin' Battleship)"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Crashin' Thrashin' Battleship"],
+		itemId = 172223,
+		items = {116762},
+		chance = 100, -- Blind guess
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		questId = {6983, 7043},
+		requiresAlliance = true
+	},
 	["Crashin' Thrashin' Flamer Controller"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
 		type = CONSTANTS.ITEM_TYPES.ITEM,

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -40,7 +40,6 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -54,7 +53,6 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -68,7 +66,6 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -82,7 +79,6 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -109,7 +105,6 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 200,  -- Guess
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043}
 	},
 	["Foot Ball"] = {		-- WHY is this item here? It can be purchased from vendor
@@ -122,7 +117,6 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -138,7 +132,6 @@ local holidayEventToys = {
 		sourceText = L["Available starting December 25th"],
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
 		questId = {8788, 8767},
-		christmasOnly = true,
 		coords = {{m = 86, x = 49.1, y = 78.2, h = true}, {m = 87, x = 33.4, y = 65.9, a = true}}
 	},
 	["MiniZep Controller"] = {
@@ -190,7 +183,6 @@ local holidayEventToys = {
 		sourceText = L["Available starting December 25th"],
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
 		questId = {8788, 8767},
-		christmasOnly = true,
 		coords = {{m = 86, x = 49.1, y = 78.2, h = true}, {m = 87, x = 33.4, y = 65.9, a = true}}
 	},
 	["Red Wooden Sled"] = {
@@ -203,7 +195,6 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -232,7 +223,6 @@ local holidayEventToys = {
 		sourceText = L["Available starting December 25th"],
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
 		questId = {8788, 8767},
-		christmasOnly = true,
 		coords = {{m = 86, x = 49.1, y = 78.2, h = true}, {m = 87, x = 33.4, y = 65.9, a = true}}
 	},
 	["Scroll of Storytelling"] = {
@@ -245,7 +235,6 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 8,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043}
 	},
 	["Silver-Plated Turkey Shooter"] = {
@@ -281,7 +270,6 @@ local holidayEventToys = {
 		items = {93626, 116762},
 		chance = 75,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043}
 	},
 	["The Heartbreaker"] = {
@@ -312,7 +300,6 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 50,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
@@ -326,7 +313,6 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 200, -- Guess
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043},
 		requiresHorde = true
 	},
@@ -340,7 +326,6 @@ local holidayEventToys = {
 		items = {116762},
 		chance = 200, -- Guess
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
-		christmasOnly = true,
 		questId = {6983, 7043},
 		requiresAlliance = true
 	},
@@ -356,7 +341,6 @@ local holidayEventToys = {
 		sourceText = L["Available starting December 25th"],
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
 		questId = {8788, 8767},
-		christmasOnly = true,
 		coords = {{m = 86, x = 49.1, y = 78.2, h = true}, {m = 87, x = 33.4, y = 65.9, a = true}}
 	}
 }

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -99,6 +99,19 @@ local holidayEventToys = {
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
+	["Endothermic Blaster"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Endothermic Blaster"],
+		itemId = 128636,
+		items = {116762},
+		chance = 200,  -- Guess
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
+		questId = {6983, 7043}
+	},
 	["Foot Ball"] = {		-- WHY is this item here? It can be purchased from vendor
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
 		type = CONSTANTS.ITEM_TYPES.ITEM,

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -271,6 +271,19 @@ local holidayEventToys = {
 			{m = 998, x = 63.4, y = 9, q = 14059, h = true}
 		}
 	},
+	["Special Edition Foot Ball"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Special Edition Foot Ball"],
+		itemId = 90888,
+		items = {93626, 116762},
+		chance = 75,
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
+		questId = {6983, 7043}
+	},
 	["The Heartbreaker"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
 		type = CONSTANTS.ITEM_TYPES.ITEM,

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -316,6 +316,34 @@ local holidayEventToys = {
 		questId = {6983, 7043},
 		coords = {{m = 25, x = 43.6, y = 39.6}}
 	},
+	["Toy Weapon Set (Horde)"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Toy Weapon Set"],
+		itemId = 151348,
+		items = {116762},
+		chance = 200, -- Guess
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
+		questId = {6983, 7043},
+		requiresHorde = true
+	},
+	["Toy Weapon Set (Alliance)"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Toy Weapon Set"],
+		itemId = 151349,
+		items = {116762},
+		chance = 200, -- Guess
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		christmasOnly = true,
+		questId = {6983, 7043},
+		requiresAlliance = true
+	},
 	["Zhevra Lounge Cushion"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
 		type = CONSTANTS.ITEM_TYPES.ITEM,

--- a/Locales.lua
+++ b/Locales.lua
@@ -1801,6 +1801,7 @@ L["Special Edition Foot Ball"] = true
 L["Toy Weapon Set"] = true
 L["Greatfather Winter's Hearthstone"] = true
 L["Wild Holly"] = true
+L["Hearthstation"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1795,6 +1795,7 @@ L["Lucy's Lost Collar"] = true
 L["Dirty Glinting Object"] = true
 L["A world event is currently available for %s! Go get it!"] = true
 L["Ny'alotha Allseer"] = true
+L["Endothermic Blaster"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1802,6 +1802,7 @@ L["Toy Weapon Set"] = true
 L["Greatfather Winter's Hearthstone"] = true
 L["Wild Holly"] = true
 L["Hearthstation"] = true
+L["Crashin' Thrashin' Battleship"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1796,6 +1796,7 @@ L["Dirty Glinting Object"] = true
 L["A world event is currently available for %s! Go get it!"] = true
 L["Ny'alotha Allseer"] = true
 L["Endothermic Blaster"] = true
+L["Scroll of Storytelling"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1800,6 +1800,7 @@ L["Scroll of Storytelling"] = true
 L["Special Edition Foot Ball"] = true
 L["Toy Weapon Set"] = true
 L["Greatfather Winter's Hearthstone"] = true
+L["Wild Holly"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1803,6 +1803,7 @@ L["Greatfather Winter's Hearthstone"] = true
 L["Wild Holly"] = true
 L["Hearthstation"] = true
 L["Crashin' Thrashin' Battleship"] = true
+L["Crashin' Thrashin' Juggernaught"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1798,6 +1798,7 @@ L["Ny'alotha Allseer"] = true
 L["Endothermic Blaster"] = true
 L["Scroll of Storytelling"] = true
 L["Special Edition Foot Ball"] = true
+L["Toy Weapon Set"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1797,6 +1797,7 @@ L["A world event is currently available for %s! Go get it!"] = true
 L["Ny'alotha Allseer"] = true
 L["Endothermic Blaster"] = true
 L["Scroll of Storytelling"] = true
+L["Special Edition Foot Ball"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1804,6 +1804,7 @@ L["Wild Holly"] = true
 L["Hearthstation"] = true
 L["Crashin' Thrashin' Battleship"] = true
 L["Crashin' Thrashin' Juggernaught"] = true
+L["Wreath-A-Rang"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1799,6 +1799,7 @@ L["Endothermic Blaster"] = true
 L["Scroll of Storytelling"] = true
 L["Special Edition Foot Ball"] = true
 L["Toy Weapon Set"] = true
+L["Greatfather Winter's Hearthstone"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Utils/DatabaseMaintenanceHelper.lua
+++ b/Utils/DatabaseMaintenanceHelper.lua
@@ -1,5 +1,5 @@
-local addonName, addon = ...
-if not addon then
+local addonName, addonTable = ...
+if not addonTable then
 	return
 end
 
@@ -11,6 +11,8 @@ local tostring = tostring
 local assert = assert
 
 -- Locals
+local CONSTANTS = addonTable.constants
+
 -- Format: fieldName = isRequiredField (optional if set to FALSE)
 local DBH = {
 	itemTypes = {
@@ -138,6 +140,28 @@ function DBH:VerifyEntry(entry)
 
 	if entry.equalOdds and not entry.groupSize then
 		print("Warning: Found setting for equalOdds but groupSize is not set")
+		return false
+	end
+
+	--[[
+      HOLIDAY VALUES ------------------------------------------------------------------------------------------------------------
+  	]]
+
+	-- All holiday items should have holidayTexture set to represent which holiday it belongs to.
+	if entry.cat == CONSTANTS.ITEM_CATEGORIES.HOLIDAY and not entry.holidayTexture then
+		print("Warning: Found holiday item without a 'holidayTexture'.")
+		return false
+	end
+
+	-- There is no reason why items should have holidayTexture unless they are in the Holiday category.
+	if entry.holidayTexture and not (entry.cat == CONSTANTS.ITEM_CATEGORIES.HOLIDAY) then
+		print("Warning: Found item with holidayTexture, but it's not a holiday item.")
+		return false
+	end
+
+	-- There is no reason why items should have christmasOnly unless they are in the Holiday category.
+	if entry.christmasOnly and not (entry.cat == CONSTANTS.ITEM_CATEGORIES.HOLIDAY) then
+		print("Warning: Found item with christmasOnly, but it's not a holiday item.")
 		return false
 	end
 


### PR DESCRIPTION
Added 5 missing items that are rewarded from the Stolen Presents during WInter Veil. This should be every missing items as far as I can tell, so should resolve #67.
EDIT: This does NOT contain the two illusions that can drop here

Added items:
- https://www.wowhead.com/item=128636	-- Endothermic Blaster
- https://www.wowhead.com/item=116456	-- Scroll of Storytelling
- https://www.wowhead.com/item=151349 -- Toy Weapon Set [Alliance]
- https://www.wowhead.com/item=151348 -- Toy Weapon Set [Horde]
- https://www.wowhead.com/item=90888	-- Special Edition Foot Ball

QuestIDs are best guess based on other items as this cannot be tested atm. Still better have potentially broken 'defeat detection' than no tracking at all.

Also went over the other items that are contained in this present and made sure they were all flagged with `christmasOnly` as they should be.
Added a couple verification routines as well in the DB Helper related to holiday items.