### PR TITLE
Added Ny'alotha Allseer

### DIFF
--- a/DB/Mounts/BattleForAzeroth.lua
+++ b/DB/Mounts/BattleForAzeroth.lua
@@ -795,6 +795,24 @@ local bfaMounts = {
 		chance = 100,
 		equalOdds = true,
 		groupSize = 3
+	},
+	-- 8.3
+	["Ny'alotha Allseer"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.BFA,
+		type = CONSTANTS.ITEM_TYPES.MOUNT,
+		method = CONSTANTS.DETECTION_METHODS.BOSS,
+		name = L["Ny'alotha Allseer"],
+		spellId = 308814,
+		itemId = 174872,
+		npcs = {99999},
+		tooltipNpcs = {158041}, -- N'Zoth the Corruptor
+		instanceDifficulties = {[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_RAID] = true},
+		chance = 100,
+		wasGuaranteed = true,
+		groupSize = 10,
+		equalOdds = true,
+		statisticId = {14138},
+		coords = {{m = CONSTANTS.UIMAPIDS.NYALOTHA, i = true}}
 	}
 }
 

--- a/Locales.lua
+++ b/Locales.lua
@@ -1794,6 +1794,7 @@ L["Piccolo of the Flaming Fire"] = true
 L["Lucy's Lost Collar"] = true
 L["Dirty Glinting Object"] = true
 L["A world event is currently available for %s! Go get it!"] = true
+L["Ny'alotha Allseer"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.


### PR DESCRIPTION
Added the mount [Ny'alotha Allseer](https://www.wowhead.com/item=174872/nyalotha-allseer) from Ny'alotha, the Waking City (BFA). Haven't added any defeat detection for this yet, but figured getting the tracking in sooner than later was more important. It'll be caught by the famous database verification tool eventually(!), so it won't be forgotten. This closes #231.