### PR TITLE
Added Gilded Wader (pet)

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1158,19 +1158,19 @@ function R:OnEvent(event, ...)
 			end
 		end
 
-		-- Handle opening Silver Strongbox & Gilded Chest (Shadowlands, Bastion nodes for Acrobatic Steward toy)
+		-- Handle opening Silver Strongbox & Gilded Chest (Bastiom, Shadowlands nodes for Acrobatic Steward (toy) and Gilded Wader (pet))
 		if
 			Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and
 				(Rarity.lastNode == L["Silver Strongbox"] or Rarity.lastNode == L["Gilded Chest"])
 		 then
-			local names = {"Acrobatic Steward"}
+			local names = {"Acrobatic Steward", "Gilded Wader"}
 			if (Rarity.lastNode == L["Silver Strongbox"]) then
 				Rarity:Debug("Detected Opening on " .. L["Silver Strongbox"] .. " (method = SPECIAL)")
 			elseif (Rarity.lastNode == L["Gilded Chest"]) then
 				Rarity:Debug("Detected Opening on " .. L["Gilded Chest"] .. " (method = SPECIAL)")
 			end
 			for _, name in pairs(names) do
-				local v = self.db.profile.groups.items[name] or self.db.profile.groups.mounts[name]
+				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
 				if v and type(v) == "table" and v.enabled ~= false then
 					if v.attempts == nil then
 						v.attempts = 1
@@ -1182,19 +1182,19 @@ function R:OnEvent(event, ...)
 			end
 		end
 
-		-- Handle opening Broken Bell & Skyward Bell (Shadowlands, Bastion nodes for Soothing Vesper toy)
+		-- Handle opening Broken Bell & Skyward Bell (Shadowlands, Bastion nodes for Soothing Vesper (toy) & Gilded Wader (pet))
 		if
 			Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and
 				(Rarity.lastNode == L["Broken Bell"] or Rarity.lastNode == L["Skyward Bell"])
 		 then
-			local names = {"Soothing Vesper"}
+			local names = {"Soothing Vesper", "Gilded Wader"}
 			if (Rarity.lastNode == L["Broken Bell"]) then
 				Rarity:Debug("Detected Opening on " .. L["Broken Bell"] .. " (method = SPECIAL)")
 			elseif (Rarity.lastNode == L["Skyward Bell"]) then
 				Rarity:Debug("Detected Opening on " .. L["Skyward Bell"] .. " (method = SPECIAL)")
 			end
 			for _, name in pairs(names) do
-				local v = self.db.profile.groups.items[name] or self.db.profile.groups.mounts[name]
+				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
 				if v and type(v) == "table" and v.enabled ~= false then
 					if v.attempts == nil then
 						v.attempts = 1

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1361,6 +1361,35 @@ function R:OnEvent(event, ...)
 			end
 		end
 
+		-- Handle opening lots of various chests for Gilded Wader (pet).
+		if
+			Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and
+				(Rarity.lastNode == L["Gift of Thenios"] or Rarity.lastNode == L["Hidden Hoard"]
+				or Rarity.lastNode == L["Memorial Offerings"] or Rarity.lastNode == L["Treasure of Courage"])
+		 then
+			local names = {"Gilded Wader"}
+			if (Rarity.lastNode == L["Gift of Thenios"]) then
+				Rarity:Debug("Detected Opening on " .. L["Gift of Thenios"] .. " (method = SPECIAL)")
+			elseif (Rarity.lastNode == L["Hidden Hoard"]) then
+				Rarity:Debug("Detected Opening on " .. L["Hidden Hoard"] .. " (method = SPECIAL)")
+			elseif (Rarity.lastNode == L["Memorial Offerings"]) then
+				Rarity:Debug("Detected Opening on " .. L["Memorial Offerings"] .. " (method = SPECIAL)")
+			elseif (Rarity.lastNode == L["Treasure of Courage"]) then
+				Rarity:Debug("Detected Opening on " .. L["Treasure of Courage"] .. " (method = SPECIAL)")
+			end
+			for _, name in pairs(names) do
+				local v = self.db.profile.groups.pets[name]
+				if v and type(v) == "table" and v.enabled ~= false then
+					if v.attempts == nil then
+						v.attempts = 1
+					else
+						v.attempts = v.attempts + 1
+					end
+					self:OutputAttempts(v)
+				end
+			end
+		end
+
 		-- Handle opening Pile of Coins
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Pile of Coins"]) then
 			local names = {"Armored Vaultbot"}

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1158,7 +1158,7 @@ function R:OnEvent(event, ...)
 			end
 		end
 
-		-- Handle opening Silver Strongbox & Gilded Chest (Bastiom, Shadowlands nodes for Acrobatic Steward (toy) and Gilded Wader (pet))
+		-- Handle opening Silver Strongbox & Gilded Chest (Bastion, Shadowlands nodes for Acrobatic Steward (toy) and Gilded Wader (pet))
 		if
 			Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and
 				(Rarity.lastNode == L["Silver Strongbox"] or Rarity.lastNode == L["Gilded Chest"])

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1164,11 +1164,7 @@ function R:OnEvent(event, ...)
 				(Rarity.lastNode == L["Silver Strongbox"] or Rarity.lastNode == L["Gilded Chest"])
 		 then
 			local names = {"Acrobatic Steward", "Gilded Wader"}
-			if (Rarity.lastNode == L["Silver Strongbox"]) then
-				Rarity:Debug("Detected Opening on " .. L["Silver Strongbox"] .. " (method = SPECIAL)")
-			elseif (Rarity.lastNode == L["Gilded Chest"]) then
-				Rarity:Debug("Detected Opening on " .. L["Gilded Chest"] .. " (method = SPECIAL)")
-			end
+			Rarity:Debug("Detected Opening on " .. Rarity.lastNode .. " (method = SPECIAL)")
 			for _, name in pairs(names) do
 				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
 				if v and type(v) == "table" and v.enabled ~= false then
@@ -1188,11 +1184,7 @@ function R:OnEvent(event, ...)
 				(Rarity.lastNode == L["Broken Bell"] or Rarity.lastNode == L["Skyward Bell"])
 		 then
 			local names = {"Soothing Vesper", "Gilded Wader"}
-			if (Rarity.lastNode == L["Broken Bell"]) then
-				Rarity:Debug("Detected Opening on " .. L["Broken Bell"] .. " (method = SPECIAL)")
-			elseif (Rarity.lastNode == L["Skyward Bell"]) then
-				Rarity:Debug("Detected Opening on " .. L["Skyward Bell"] .. " (method = SPECIAL)")
-			end
+			Rarity:Debug("Detected Opening on " .. Rarity.lastNode .. " (method = SPECIAL)")
 			for _, name in pairs(names) do
 				local v = self.db.profile.groups.items[name] or self.db.profile.groups.pets[name]
 				if v and type(v) == "table" and v.enabled ~= false then
@@ -1368,15 +1360,7 @@ function R:OnEvent(event, ...)
 				or Rarity.lastNode == L["Memorial Offerings"] or Rarity.lastNode == L["Treasure of Courage"])
 		 then
 			local names = {"Gilded Wader"}
-			if (Rarity.lastNode == L["Gift of Thenios"]) then
-				Rarity:Debug("Detected Opening on " .. L["Gift of Thenios"] .. " (method = SPECIAL)")
-			elseif (Rarity.lastNode == L["Hidden Hoard"]) then
-				Rarity:Debug("Detected Opening on " .. L["Hidden Hoard"] .. " (method = SPECIAL)")
-			elseif (Rarity.lastNode == L["Memorial Offerings"]) then
-				Rarity:Debug("Detected Opening on " .. L["Memorial Offerings"] .. " (method = SPECIAL)")
-			elseif (Rarity.lastNode == L["Treasure of Courage"]) then
-				Rarity:Debug("Detected Opening on " .. L["Treasure of Courage"] .. " (method = SPECIAL)")
-			end
+			Rarity:Debug("Detected Opening on " .. Rarity.lastNode .. " (method = SPECIAL)")
 			for _, name in pairs(names) do
 				local v = self.db.profile.groups.pets[name]
 				if v and type(v) == "table" and v.enabled ~= false then

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1354,10 +1354,18 @@ function R:OnEvent(event, ...)
 		end
 
 		-- Handle opening lots of various chests for Gilded Wader (pet).
+		local nodesGildedWader = {
+			[L["Gift of Thenios"]] = true,
+			[L["Hidden Hoard"]] = true,
+			[L["Memorial Offerings"]] = true,
+			[L["Treasure of Courage"]] = true,
+		}
+		local isRelevantNode = false
+		if Rarity.lastNode then
+			isRelevantNode = nodesGildedWader[Rarity.lastNode]
+		end
 		if
-			Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and
-				(Rarity.lastNode == L["Gift of Thenios"] or Rarity.lastNode == L["Hidden Hoard"]
-				or Rarity.lastNode == L["Memorial Offerings"] or Rarity.lastNode == L["Treasure of Courage"])
+			Rarity.isFishing and Rarity.isOpening and isRelevantNode
 		 then
 			local names = {"Gilded Wader"}
 			Rarity:Debug("Detected Opening on " .. Rarity.lastNode .. " (method = SPECIAL)")

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -242,5 +242,9 @@ R.opennodes = {
 	[L["Secret Treasure"]] = true,
 	[L["Forgotten Chest"]] = true,
 	[L["Cache of Eyes"]] = true,
-	[L["Dirty Glinting Object"]] = true
+	[L["Dirty Glinting Object"]] = true,
+	[L["Gift of Thenios"]] = true,
+	[L["Hidden Hoard"]] = true,
+	[L["Memorial Offerings"]] = true,
+	[L["Treasure of Courage"]] = true
 }

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -675,6 +675,19 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.CASTLE_NATHRIA, i = true}
 		}
 	},
+	["Gilded Wader"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+		name = L["Gilded Wader"],
+		itemId = 180866,
+		spellId = 335076,
+		creatureId = 171710,
+		chance = 300, -- Estimate
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.BASTION}
+		}
+	}
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Spells.lua
+++ b/DB/Spells.lua
@@ -21,6 +21,7 @@ Rarity.relevantSpells = {
 	-- 8.3
 	[312881] = "Searching Mailbox",
 	-- 9.0
+	[329997] = "Opening", -- Silver Strongbox (Basion, Shadowlands)
 	[345071] = "Looting", -- Dirty Glinting Object (Shadowlands zones for Lucy's Lost Collar pet)
 	-- Not tested (but added just in case)
 	[7731] = "Fishing",

--- a/DB/Spells.lua
+++ b/DB/Spells.lua
@@ -21,7 +21,7 @@ Rarity.relevantSpells = {
 	-- 8.3
 	[312881] = "Searching Mailbox",
 	-- 9.0
-	[329997] = "Opening", -- Silver Strongbox (Basion, Shadowlands)
+	[329997] = "Opening", -- Silver Strongbox (Bastion, Shadowlands)
 	[345071] = "Looting", -- Dirty Glinting Object (Shadowlands zones for Lucy's Lost Collar pet)
 	-- Not tested (but added just in case)
 	[7731] = "Fishing",

--- a/Locales.lua
+++ b/Locales.lua
@@ -1806,6 +1806,10 @@ L["Crashin' Thrashin' Juggernaught"] = true
 L["Wreath-A-Rang"] = true
 L["Glacial Tidestorm"] = true
 L["Gilded Wader"] = true
+L["Gift of Thenios"] = true
+L["Hidden Hoard"] = true
+L["Memorial Offerings"] = true
+L["Treasure of Courage"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1805,6 +1805,7 @@ L["Crashin' Thrashin' Battleship"] = true
 L["Crashin' Thrashin' Juggernaught"] = true
 L["Wreath-A-Rang"] = true
 L["Glacial Tidestorm"] = true
+L["Gilded Wader"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.


### PR DESCRIPTION
Added the [Gilded Wader](https://www.wowhead.com/item=180866/gilded-wader). Once finished, this closes #278.

Status:

- [x] Add pet to DB incl. locales
- [x] Add tracking to existing nodes
- [x] Add all new nodes + locales for this pet based on Wowheads 'contained in'.
- [x] ~~Scrape wowhead comments for additional nodes~~ (See below)
- [x] ~~Look for any hidden daily lockouts.~~ (No indication of this found.)
- [x] Testing

There are multiple reports of various other nodes also dropping this pet besides the ones listed on Wowheads 'contained in'. I have not added tracking for any of those at this moment. That is because allthough I don't doubt the wowhead comments, there just aren't any screenshots or other proof to verify these nodes to drop the pet. Mostly there is just a single report on any given source. I am leaving the others until someone can prove them.

Reported but not confirmed:
```
[Penitence of Purity] in Bastion (Kyrian only)
[Greed's Desire] Crypt of the forgotten, Revendreth
[Runebound Chest] Maldraxxus
[Stoneborn Satchel] Revendreth (has a vague screenshot)
[Pugilist's Prize] Revendreth
[Bleakwood Chest] Revendreth
```