### PR TITLE
Added missing BMAH tag to items

### DIFF
--- a/DB/Mounts/Cataclysm.lua
+++ b/DB/Mounts/Cataclysm.lua
@@ -14,6 +14,7 @@ local cataclysmMounts = {
 		itemId = 68823,
 		npcs = {52151},
 		chance = 100,
+		blackMarket = true,
 		sourceText = L["Heroic difficulty"],
 		lockBossName = "Bloodlord Mandokir",
 		coords = {{m = 337, x = 60.4, y = 79.9, i = true}}
@@ -31,6 +32,7 @@ local cataclysmMounts = {
 		statisticId = {6161, 6162},
 		sourceText = L["Dropped by Ultraxion in Dragon Soul (any raid size or difficulty)"],
 		lockBossName = "Ultraxion",
+		blackMarket = true,
 		coords = {{m = 409, x = 49.6, y = 57.6, i = true}}
 	},
 	["Flametalon of Alysrazor"] = {
@@ -273,6 +275,7 @@ local cataclysmMounts = {
 		itemId = 68824,
 		npcs = {52059},
 		chance = 100,
+		blackMarket = true,
 		sourceText = L["Heroic difficulty"],
 		lockBossName = "High Priestess Kilnara",
 		coords = {{m = 337, x = 48, y = 20, i = true}}

--- a/DB/Mounts/Legion.lua
+++ b/DB/Mounts/Legion.lua
@@ -37,6 +37,7 @@ local legionMounts = {
 		itemId = 143764,
 		items = {152105},
 		chance = 20,
+		blackMarket = true,
 		coords = {{m = CONSTANTS.UIMAPIDS.SURAMAR}}
 	},
 	["Torn Invitation"] = {
@@ -60,6 +61,7 @@ local legionMounts = {
 		itemId = 147805,
 		items = {152106},
 		chance = 20,
+		blackMarket = true,
 		coords = {{m = CONSTANTS.UIMAPIDS.STORMHEIM}}
 	},
 	["Wild Dreamrunner"] = {
@@ -129,6 +131,7 @@ local legionMounts = {
 		npcs = {127288},
 		chance = 30,
 		questId = 48821,
+		blackMarket = true,
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.ANTORAN_WASTES, x = 62.96, y = 24.86, n = L["Houndmaster Kerrax"]}
 		}

--- a/DB/Mounts/Legion.lua
+++ b/DB/Mounts/Legion.lua
@@ -332,6 +332,7 @@ local legionMounts = {
 		chance = 100,
 		groupSize = 3,
 		equalOdds = true,
+		blackMarket = true,
 		statisticId = {11893, 11894, 11895, 11896},
 		coords = {{m = 851, i = true}}
 	},
@@ -351,6 +352,7 @@ local legionMounts = {
 		chance = 100,
 		groupSize = 3,
 		equalOdds = true,
+		blackMarket = true,
 		statisticId = {10979, 10980, 10978},
 		coords = {{m = 772, i = true}}
 	},
@@ -414,6 +416,7 @@ local legionMounts = {
 		wasGuaranteed = true,
 		groupSize = 3,
 		equalOdds = true,
+		blackMarket = true,
 		statisticId = {11986},
 		coords = {{m = 910, i = true}}
 	}

--- a/DB/Mounts/MistsOfPandaria.lua
+++ b/DB/Mounts/MistsOfPandaria.lua
@@ -24,6 +24,7 @@ local mopMounts = {
 		statisticId = {8171, 8169, 8172, 8170},
 		sourceText = L["All raid formats except Raid Finder"],
 		lockBossName = "Ji-Kun",
+		blackMarket = true,
 		coords = {{m = 510, x = 49.7, y = 41.6, i = true}}
 	},
 	["Kor'kron Juggernaut"] = {
@@ -40,6 +41,7 @@ local mopMounts = {
 		statisticId = {8638, 8637},
 		sourceText = L["Mythic difficulty"],
 		wasGuaranteed = true,
+		blackMarket = true,
 		lockBossName = "Garrosh Hellscream",
 		coords = {{m = 567, x = 49.4, y = 71.3, i = true}}
 	},
@@ -52,6 +54,7 @@ local mopMounts = {
 		itemId = 94230,
 		npcs = {69841},
 		chance = 20,
+		blackMarket = true,
 		sourceText = L["The Warbringer will be riding the mount color he has a chance to drop."],
 		coords = {
 			{m = 418, x = 39.08, y = 67.13},
@@ -137,6 +140,7 @@ local mopMounts = {
 		statisticId = {8147},
 		enableCoin = true,
 		worldBossFactionless = true,
+		blackMarket = true,
 		coords = {{m = 507, x = 50.6, y = 54.4}}
 	},
 	["Reins of the Heavenly Onyx Cloud Serpent"] = {
@@ -171,6 +175,7 @@ local mopMounts = {
 		itemId = 94231,
 		npcs = {69842},
 		chance = 20,
+		blackMarket = true,
 		sourceText = L["The Warbringer will be riding the mount color he has a chance to drop."],
 		coords = {
 			{m = 418, x = 39.08, y = 67.13},
@@ -189,6 +194,7 @@ local mopMounts = {
 		itemId = 94229,
 		npcs = {69769},
 		chance = 20,
+		blackMarket = true,
 		sourceText = L["The Warbringer will be riding the mount color he has a chance to drop."],
 		coords = {
 			{m = 418, x = 39.08, y = 67.13},
@@ -241,6 +247,7 @@ local mopMounts = {
 		statisticId = {6990},
 		enableCoin = true,
 		worldBossFactionless = true,
+		blackMarket = true,
 		coords = {{m = 376, x = 71.6, y = 64.4}}
 	},
 	["Spawn of Horridon"] = {
@@ -262,6 +269,7 @@ local mopMounts = {
 		statisticId = {8151, 8149, 8152, 8150},
 		sourceText = L["All raid formats except Raid Finder"],
 		lockBossName = "Horridon",
+		blackMarket = true,
 		coords = {{m = 508, x = 26.8, y = 78.7, i = true}}
 	}
 }

--- a/DB/Mounts/MistsOfPandaria.lua
+++ b/DB/Mounts/MistsOfPandaria.lua
@@ -230,6 +230,7 @@ local mopMounts = {
 		itemId = 104269,
 		npcs = {73167},
 		chance = 100,
+		blackMarket = true,
 		sourceText = L["Players have a personal loot chance to obtain this item."],
 		coords = {{m = 554, x = 67.8, y = 59}}
 	},

--- a/DB/Mounts/WarlordsOfDraenor.lua
+++ b/DB/Mounts/WarlordsOfDraenor.lua
@@ -114,6 +114,7 @@ local wodMounts = {
 		itemId = 23720,
 		npcs = {81171, 85715},
 		chance = 200,
+		blackMarket = true,
 		sourceText = L[
 			"After upgrading your garrison's Fishing Shack to level 3, fish up 5 minnows to summon a Cavedweller which can drop this mount."
 		],

--- a/DB/Mounts/WarlordsOfDraenor.lua
+++ b/DB/Mounts/WarlordsOfDraenor.lua
@@ -231,6 +231,7 @@ local wodMounts = {
 		tooltipNpcs = {91331},
 		chance = 100,
 		wasGuaranteed = true,
+		blackMarket = true,
 		statisticId = {10252},
 		lockBossName = "Archimonde",
 		coords = {{m = 670, x = 58.4, y = 53.3, i = true}}
@@ -257,6 +258,7 @@ local wodMounts = {
 		tooltipNpcs = {77325},
 		chance = 100,
 		wasGuaranteed = true,
+		blackMarket = true,
 		statisticId = {9365},
 		lockBossName = "Blackhand",
 		coords = {{m = 600, x = 48.4, y = 34.5, i = true}}
@@ -273,6 +275,7 @@ local wodMounts = {
 		chance = 500,
 		statisticId = {9279},
 		worldBossFactionless = true,
+		blackMarket = true,
 		questId = 37464,
 		coords = {
 			{

--- a/DB/Mounts/WrathOfTheLichKing.lua
+++ b/DB/Mounts/WrathOfTheLichKing.lua
@@ -104,6 +104,7 @@ local wotlkMounts = {
 		tooltipNpcs = {35013, 33993, 31125, 38433},
 		chance = 100,
 		requiresAlliance = true,
+		blackMarket = true,
 		statisticId = {1753, 1754, 2870, 3236, 4074, 4075, 4657, 4658},
 		sourceText = L[
 			"Dropped by Koralon the Flame Watcher, Emalon the Storm Watcher, Archavon the Stone Watcher, and Toravon the Ice Watcher in Vault of Archavon (any raid size)."
@@ -127,6 +128,7 @@ local wotlkMounts = {
 		tooltipNpcs = {35013, 33993, 31125, 38433},
 		chance = 100,
 		requiresHorde = true,
+		blackMarket = true,
 		statisticId = {1753, 1754, 2870, 3236, 4074, 4075, 4657, 4658},
 		sourceText = L[
 			"Dropped by Koralon the Flame Watcher, Emalon the Storm Watcher, Archavon the Stone Watcher, and Toravon the Ice Watcher in Vault of Archavon (any raid size)."

--- a/DB/Pets/Classic.lua
+++ b/DB/Pets/Classic.lua
@@ -15,6 +15,7 @@ local classicPets = {
 		zones = {"25"},
 		chance = 10000,
 		creatureId = 7383,
+		blackMarket = true,
 		coords = {{m = 25}}
 	},
 	["Dark Whelpling"] = {
@@ -27,6 +28,7 @@ local classicPets = {
 		npcs = {4324, 42042, 2725, 46916, 7049, 4323, 46914},
 		chance = 1000,
 		creatureId = 7543,
+		blackMarket = true,
 		coords = {
 			{m = 15, x = 29.6, y = 44.2},
 			{m = 15, x = 71.8, y = 47.6},
@@ -47,6 +49,7 @@ local classicPets = {
 		items = {20768},
 		chance = 85,
 		creatureId = 15429,
+		blackMarket = true,
 		tooltipNpcs = {
 			1806,
 			1808,
@@ -122,6 +125,7 @@ local classicPets = {
 		npcs = {48522},
 		chance = 33,
 		creatureId = 7387,
+		blackMarket = true,
 		coords = {{m = 291, x = 55, y = 39.6, i = true}}
 	},
 	["Parrot Cage (Hyacinth Macaw)"] = {
@@ -134,6 +138,7 @@ local classicPets = {
 		zones = {"224", "50", "210"},
 		chance = 10000,
 		creatureId = 7391,
+		blackMarket = true,
 		coords = {{m = 50}, {m = 210}}
 	},
 	["Sprite Darter Egg"] = {
@@ -158,6 +163,7 @@ local classicPets = {
 		zones = {"56"},
 		chance = 10000,
 		creatureId = 7544,
+		blackMarket = true,
 		coords = {{m = 56}}
 	},
 	["Emerald Whelpling"] = {
@@ -170,6 +176,7 @@ local classicPets = {
 		npcs = {740, 741, 39384},
 		chance = 1000,
 		creatureId = 7545,
+		blackMarket = true,
 		coords = {{m = 69, x = 49.6, y = 8.6}}
 	}
 }

--- a/DB/Pets/MistsOfPandaria.lua
+++ b/DB/Pets/MistsOfPandaria.lua
@@ -230,6 +230,7 @@ local mopPets = {
 		statisticId = {8171, 8169, 8172, 8170, 8168},
 		creatureId = 70144,
 		enableCoin = true,
+		blackMarket = true,
 		lockBossName = "Ji-Kun",
 		coords = {{m = 508, x = 49.3, y = 41.5, i = true}}
 	},
@@ -246,6 +247,7 @@ local mopPets = {
 		doNotUpdateToHighestStat = true,
 		creatureId = 69748,
 		enableCoin = true,
+		blackMarket = true,
 		coords = {{m = 508, i = true}}
 	},
 	["Mountain Panda"] = {
@@ -301,6 +303,7 @@ local mopPets = {
 		statisticId = {8186, 8184, 8187, 8185, 8183},
 		creatureId = 69820,
 		enableCoin = true,
+		blackMarket = true,
 		lockBossName = "Dark Animus",
 		coords = {{m = 508, x = 42.6, y = 57.6, i = true}}
 	},
@@ -428,6 +431,7 @@ local mopPets = {
 		statisticId = {8181, 8179, 8180, 8182},
 		creatureId = 71200,
 		enableCoin = true,
+		blackMarket = true,
 		sourceText = L["All raid formats except Raid Finder"],
 		lockBossName = "Primordius",
 		coords = {{m = 508, i = true, x = 57.2, y = 78.2}}
@@ -505,6 +509,7 @@ local mopPets = {
 		statisticId = {8151, 8149, 8152, 8150, 8148},
 		creatureId = 70083,
 		enableCoin = true,
+		blackMarket = true,
 		lockBossName = "Horridon",
 		coords = {{m = 508, 26.8, y = 78.7, i = true}}
 	},
@@ -522,6 +527,7 @@ local mopPets = {
 		statisticId = {8178},
 		creatureId = 71199,
 		enableCoin = true,
+		blackMarket = true,
 		sourceText = L["Only Raid Finder difficulty"],
 		lockBossName = "Primordius",
 		coords = {{m = 508, x = 57.2, y = 78.2, i = true}}
@@ -621,6 +627,7 @@ local mopPets = {
 		npcs = {99999},
 		tooltipNpcs = {71504},
 		chance = 100,
+		blackMarket = true,
 		statisticId = {8624, 8622, 8625, 8623, 8621, 8620},
 		creatureId = 73352,
 		lockBossName = "Siegecrafter Blackfuse",
@@ -682,6 +689,7 @@ local mopPets = {
 		statisticId = {8569, 8571, 8573, 8570, 8568},
 		creatureId = 73350,
 		enableCoin = true,
+		blackMarket = true,
 		sourceText = L["All raid formats except Raid Finder"],
 		lockBossName = "Sha of Pride",
 		coords = {{m = 556, x = 22.5, y = 69.5, i = true}}
@@ -703,6 +711,7 @@ local mopPets = {
 		statisticId = {8568, 8567},
 		creatureId = 73351,
 		enableCoin = true,
+		blackMarket = true,
 		sourceText = L["Raid Finder or Flexible difficulty"],
 		lockBossName = "Sha of Pride",
 		coords = {{m = 556, x = 22.5, y = 69.5, i = true}}
@@ -768,6 +777,7 @@ local mopPets = {
 		statisticId = {8630, 8628, 8631, 8629, 8627, 8626},
 		creatureId = 73354,
 		enableCoin = true,
+		blackMarket = true,
 		lockBossName = "Paragons of the Klaxxi",
 		coords = {{m = 556, x = 68.3, y = 35.3, i = true}}
 	}, -- PARAGONS OF THE KLAXXI (all modes)

--- a/DB/Pets/TheBurningCrusade.lua
+++ b/DB/Pets/TheBurningCrusade.lua
@@ -15,6 +15,7 @@ local tbcPets = {
 		zones = {"83"},
 		chance = 10000,
 		creatureId = 7547,
+		blackMarket = true,
 		coords = {{m = 83}}
 	},
 	["Captured Firefly"] = {
@@ -27,6 +28,7 @@ local tbcPets = {
 		npcs = {20197},
 		chance = 1000,
 		creatureId = 21076,
+		blackMarket = true,
 		coords = {{m = 102, x = 47.6, y = 32.6}}
 	},
 	["Mojo"] = {
@@ -51,6 +53,7 @@ local tbcPets = {
 		npcs = {24664},
 		chance = 11,
 		creatureId = 26119,
+		blackMarket = true,
 		coords = {{m = 348, x = 8.6, y = 50.2, i = true, n = L["Kael'thas Sunstrider"]}}
 	},
 	["Chuck's Bucket"] = {

--- a/DB/Pets/WrathOfTheLichKing.lua
+++ b/DB/Pets/WrathOfTheLichKing.lua
@@ -15,6 +15,7 @@ local wotlkPets = {
 		npcs = {3636, 3637},
 		chance = 500,
 		creatureId = 35395,
+		blackMarket = true,
 		coords = {{m = 279}}
 	},
 	["Giant Sewer Rat"] = {
@@ -27,6 +28,7 @@ local wotlkPets = {
 		zones = {"Cantrips & Crows", "Circle of Wills", "The Underbelly", "The Black Market"},
 		chance = 1000,
 		requiresPool = false,
+		blackMarket = true,
 		creatureId = 31575,
 		coords = {{m = 125}}
 	},
@@ -40,6 +42,7 @@ local wotlkPets = {
 		npcs = {29334},
 		chance = 1000,
 		creatureId = 35400,
+		blackMarket = true,
 		coords = {{m = 121}}
 	},
 	["Razzashi Hatchling"] = {
@@ -52,6 +55,7 @@ local wotlkPets = {
 		zones = {"224", "50", "210"},
 		chance = 5000,
 		creatureId = 35394,
+		blackMarket = true,
 		coords = {{m = 224}, {m = 50}, {m = 210}}
 	}
 }


### PR DESCRIPTION
I've gone over the list of items available on the Black Market Auction House and I've added `blackMarket = true` to all relevant items in the database where this was missing. This closes #335.