### PR TITLE
Added defeat detection to Hopecrusher Gargon

### DIFF
--- a/DB/Mounts/Shadowlands.lua
+++ b/DB/Mounts/Shadowlands.lua
@@ -48,6 +48,7 @@ local shadowlandsMounts = {
 		chance = 100,
 		groupSize = 5,
 		equalOdds = true,
+		questId = {59900},
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.REVENDRETH, x = 51.98, y = 51.80, n = L["Hopecrusher"]}
 		},


### PR DESCRIPTION
Here comes more missing detection. This time the Venthyr only rare mount [Hopecrusher Gargon](https://www.wowhead.com/item=180581/hopecrusher-gargon).