### PR TITLE
DB: Added defeat detection for Fandral's Seed Pouch

### DIFF
--- a/DB/Toys/WarlordsOfDraenor.lua
+++ b/DB/Toys/WarlordsOfDraenor.lua
@@ -63,6 +63,25 @@ local wodToys = {
 			["WARLOCK"] = true,
 			["WARRIOR"] = true
 		},
+		lockoutDetails = {
+			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
+			{
+				encounterName = "Majordomo Staghelm",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.NORMAL_RAID] = true
+				}
+			},
+			{
+				encounterName = "Majordomo Staghelm",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.HEROIC_RAID] = true
+				}
+			},
+		},
+		instanceDifficulties = {
+			[CONSTANTS.INSTANCE_DIFFICULTIES.NORMAL_RAID] = true,
+			[CONSTANTS.INSTANCE_DIFFICULTIES.HEROIC_RAID] = true,
+		},
 		sourceText = L["Will only drop for druids."],
 		coords = {{m = 369, x = 50.9, y = 72.4, i = true}}
 	},


### PR DESCRIPTION
As per title, I have been grinding [this stupid toy](https://www.wowhead.com/item=122304/fandrals-seed-pouch) and decided to add the defeat detection along the way.