### PR TITLE
9.1 toys

### DIFF
--- a/DB/Toys/Shadowlands.lua
+++ b/DB/Toys/Shadowlands.lua
@@ -300,6 +300,20 @@ local shadowlandsToys = {
 			{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 47.0, y = 35.5, n = L["Wild Worldcracker"]}
 		}
 	},
+	["Bonestorm Top"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Bonestorm Top"],
+		isToy = true,
+		itemId = 183901,
+		npcs = {158025},
+		chance = 100, -- Blind guess
+		unique = true,
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.THE_MAW, x = 48.8, y = 81.4, n = L["Darklord Taraxis"]}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.toys, shadowlandsToys)

--- a/DB/Toys/Shadowlands.lua
+++ b/DB/Toys/Shadowlands.lua
@@ -341,6 +341,20 @@ local shadowlandsToys = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW, x = 28.5, y = 24.9, n = L["Torglluun"]}
 		}
 	},
+	["Maw-Ocular Viewfinder"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Maw-Ocular Viewfinder"],
+		isToy = true,
+		itemId = 187420,
+		npcs = {179914},
+		chance = 100, -- Blind guess
+		unique = true,
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 50.2, y = 75.4, n = L["Observer Yorik"]}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.toys, shadowlandsToys)

--- a/DB/Toys/Shadowlands.lua
+++ b/DB/Toys/Shadowlands.lua
@@ -314,6 +314,19 @@ local shadowlandsToys = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW, x = 48.8, y = 81.4, n = L["Darklord Taraxis"]}
 		}
 	},
+	["Vesper of Faith"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Vesper of Faith"],
+		itemId = 187185,
+		items = {185993},
+		chance = 100, -- Blind guess
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.THE_MAW}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.toys, shadowlandsToys)

--- a/DB/Toys/Shadowlands.lua
+++ b/DB/Toys/Shadowlands.lua
@@ -327,6 +327,20 @@ local shadowlandsToys = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW}
 		}
 	},
+	["Bottled Shade Heart"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Bottled Shade Heart"],
+		isToy = true,
+		itemId = 187139,
+		npcs = {179735},
+		chance = 100, -- Blind guess
+		unique = true,
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.THE_MAW, x = 28.5, y = 24.9, n = L["Torglluun"]}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.toys, shadowlandsToys)

--- a/DB/Toys/Shadowlands.lua
+++ b/DB/Toys/Shadowlands.lua
@@ -263,7 +263,7 @@ local shadowlandsToys = {
 		name = L["Gravewing Crystal"],
 		itemId = 187283,
 		npcs = {179985},
-		chance = 100,
+		chance = 100, -- Blind guess
 		unique = true,
 		requiresCovenant = true,
 		requiredCovenantID = CONSTANTS.COVENANT_IDS.VENTHYR,
@@ -278,12 +278,26 @@ local shadowlandsToys = {
 		name = L["Small Corpsefly Egg"],
 		itemId = 187181,
 		npcs = {180042},
-		chance = 100,
+		chance = 100, -- Blind guess
 		unique = true,
 		requiresCovenant = true,
 		requiredCovenantID = CONSTANTS.COVENANT_IDS.NECROLORD,
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 59.7, y = 43.3, n = L["Fleshwing"]},
+		}
+	},
+	["Vesper of Harmony"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Vesper of Harmony"],
+		isToy = true,
+		itemId = 187176,
+		npcs = {180032},
+		chance = 100, -- Blind guess
+		unique = true,
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 47.0, y = 35.5, n = L["Wild Worldcracker"]}
 		}
 	},
 }

--- a/Locales.lua
+++ b/Locales.lua
@@ -1839,6 +1839,7 @@ L["Fleshwing"] = true
 L["Vesper of Harmony"] = true
 L["Bonestorm Top"] = true
 L["Darklord Taraxis"] = true
+L["Vesper of Faith"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1837,6 +1837,8 @@ L["Stygian Stonecrusher"] = true
 L["Small Corpsefly Egg"] = true
 L["Fleshwing"] = true
 L["Vesper of Harmony"] = true
+L["Bonestorm Top"] = true
+L["Darklord Taraxis"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1836,6 +1836,7 @@ L["Gravewing Crystal"] = true
 L["Stygian Stonecrusher"] = true
 L["Small Corpsefly Egg"] = true
 L["Fleshwing"] = true
+L["Vesper of Harmony"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1842,6 +1842,8 @@ L["Darklord Taraxis"] = true
 L["Vesper of Faith"] = true
 L["Bottled Shade Heart"] = true
 L["Torglluun"] = true
+L["Maw-Ocular Viewfinder"] = true
+L["Observer Yorik"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1840,6 +1840,8 @@ L["Vesper of Harmony"] = true
 L["Bonestorm Top"] = true
 L["Darklord Taraxis"] = true
 L["Vesper of Faith"] = true
+L["Bottled Shade Heart"] = true
+L["Torglluun"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.


### PR DESCRIPTION
Added the few new toys that is possible to add at this point. Going by the list on #356.

> * [X]  https://www.wowhead.com/item=187176/vesper-of-harmony
> * [X]  https://www.wowhead.com/item=183901/bonestorm-top
> * [X]  https://www.wowhead.com/item=187185/vesper-of-faith
> * [X]  https://www.wowhead.com/item=187139/bottled-shade-heart
> * [X]  https://www.wowhead.com/item=187420/maw-ocular-viewfinder

Also missing defeat detection and some waypoints.

Remaining toys are separated into new issues.