### PR TITLE
Add tracking for (the majority of) pets that were introduced in patch 9.1

### DIFF
--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -886,6 +886,20 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.KORTHIA}
 		}
 	},
+	["Rook"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Rook"],
+		itemId = 186552,
+		items = {186658},
+		spellId = 353661,
+		creatureId = 179242,
+		chance = 100, -- Blind guess
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.THE_MAW}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -999,6 +999,21 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW, n = L["Helsworn Soulseeker"]}
 		}
 	},
+	["Korthian Specimen"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Korthian Specimen"],
+		itemId = 186542,
+		spellId = 353663,
+		creatureId = 179251,
+		npcs = {177336},
+		chance = 50, -- Blind guess
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 30.3, y = 54.9, n = L["Cave Entrance"]},
+			{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 44.3, y = 67.1, n = L["Zelnithop"]}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -929,6 +929,20 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.TAZAVESH_THE_VEILED_MARKET, n = L["P.O.S.T. Master"]}
 		}
 	},
+	["Invasive Buzzer"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Invasive Buzzer"],
+		itemId = 186547,
+		items = {185991},
+		spellId = 353569,
+		creatureId = 179180,
+		chance = 100, -- Blind guess
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.THE_MAW}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -719,6 +719,57 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.SANCTUM_OF_DOMINATION, i = true}
 		}
 	},
+	["Eye of Allseeing"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.BOSS,
+		name = L["Eye of Allseeing"],
+		itemId = 186554,
+		spellId = 353648,
+		creatureId = 179232,
+		npcs = {99999},
+		tooltipNpcs = {180018},
+		chance = 100, -- Blind guess
+		statisticId = {15140, 15143, 15142, 15141}, -- All difficulties.
+		groupSize = 10,
+		equalOdds = true,
+		instanceDifficulties = {
+			[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_RAID] = true,
+			[CONSTANTS.INSTANCE_DIFFICULTIES.HEROIC_RAID] = true,
+			[CONSTANTS.INSTANCE_DIFFICULTIES.NORMAL_RAID] = true,
+			[CONSTANTS.INSTANCE_DIFFICULTIES.LFR] = true
+		},
+		lockoutDetails = {
+			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
+			{
+				encounterName = "Eye of the Jailer",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_RAID] = true
+				}
+			},
+			{
+				encounterName = "Eye of the Jailer",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.HEROIC_RAID] = true
+				}
+			},
+			{
+				encounterName = "Eye of the Jailer",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.NORMAL_RAID] = true
+				}
+			},
+			{
+				encounterName = "Eye of the Jailer",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.LFR] = true
+				}
+			},
+		},
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.SANCTUM_OF_DOMINATION, i = true}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -687,7 +687,38 @@ local shadowlandsPets = {
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.BASTION}
 		}
-	}
+	},
+	-- 9.1 pets
+	["Eye of Extermination"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.BOSS,
+		name = L["Eye of Extermination"],
+		itemId = 186555,
+		spellId = 353649,
+		creatureId = 179233,
+		npcs = {99999},
+		tooltipNpcs = {180018},
+		chance = 100, -- Blind guess
+		statisticId = {15143}, -- Mythic is only confirmed source.
+		groupSize = 25,
+		equalOdds = true,
+		instanceDifficulties = {
+			[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_RAID] = true,
+		},
+		lockoutDetails = {
+			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
+			{
+				encounterName = "Eye of the Jailer",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_RAID] = true
+				}
+			},
+		},
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.SANCTUM_OF_DOMINATION, i = true}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -943,6 +943,20 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW}
 		}
 	},
+	["Copperback Etherwyrm"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Copperback Etherwyrm"],
+		itemId = 186546,
+		items = {185993},
+		spellId = 353451,
+		creatureId = 179132,
+		chance = 100, -- Blind guess
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.THE_MAW}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -770,6 +770,57 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.SANCTUM_OF_DOMINATION, i = true}
 		}
 	},
+	["Irongrasp"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.BOSS,
+		name = L["Irongrasp"],
+		itemId = 186558,
+		spellId = 353639,
+		creatureId = 179222,
+		npcs = {99999},
+		tooltipNpcs = {175727},
+		chance = 100, -- Blind guess
+		statisticId = {15155, 15153, 15154, 15152}, -- All difficulties.
+		groupSize = 10,
+		equalOdds = true,
+		instanceDifficulties = {
+			[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_RAID] = true,
+			[CONSTANTS.INSTANCE_DIFFICULTIES.HEROIC_RAID] = true,
+			[CONSTANTS.INSTANCE_DIFFICULTIES.NORMAL_RAID] = true,
+			[CONSTANTS.INSTANCE_DIFFICULTIES.LFR] = true
+		},
+		lockoutDetails = {
+			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
+			{
+				encounterName = "Soulrender Dormazain",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_RAID] = true
+				}
+			},
+			{
+				encounterName = "Soulrender Dormazain",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.HEROIC_RAID] = true
+				}
+			},
+			{
+				encounterName = "Soulrender Dormazain",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.NORMAL_RAID] = true
+				}
+			},
+			{
+				encounterName = "Soulrender Dormazain",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.LFR] = true
+				}
+			},
+		},
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.SANCTUM_OF_DOMINATION, i = true}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -985,6 +985,20 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW, n = L["Gralebboih"]}
 		}
 	},
+	["Golden Eye"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Golden Eye"],
+		itemId = 186564,
+		spellId = 353644,
+		creatureId = 179228,
+		npcs = {177132},
+		chance = 100, -- Blind guess
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.THE_MAW, n = L["Helsworn Soulseeker"]}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -914,6 +914,21 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW}
 		}
 	},
+	["Gizmo"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Gizmo"],
+		itemId = 186534,
+		spellId = 353525,
+		creatureId = 179166,
+		npcs = {175646},
+		chance = 100, -- Blind guess
+		instanceDifficulties = {[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true},
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.TAZAVESH_THE_VEILED_MARKET, n = L["P.O.S.T. Master"]}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -821,6 +821,57 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.SANCTUM_OF_DOMINATION, i = true}
 		}
 	},
+	["Mawsworn Minion"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.BOSS,
+		name = L["Mawsworn Minion"],
+		itemId = 186550,
+		spellId = 353658,
+		creatureId = 179240,
+		npcs = {99999},
+		tooltipNpcs = {15990},
+		chance = 100, -- Blind guess
+		statisticId = {15169, 15171, 15172, 15170}, -- All difficulties.
+		groupSize = 10,
+		equalOdds = true,
+		instanceDifficulties = {
+			[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_RAID] = true,
+			[CONSTANTS.INSTANCE_DIFFICULTIES.HEROIC_RAID] = true,
+			[CONSTANTS.INSTANCE_DIFFICULTIES.NORMAL_RAID] = true,
+			[CONSTANTS.INSTANCE_DIFFICULTIES.LFR] = true
+		},
+		lockoutDetails = {
+			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
+			{
+				encounterName = "Kel'Thuzad",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_RAID] = true
+				}
+			},
+			{
+				encounterName = "Kel'Thuzad",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.HEROIC_RAID] = true
+				}
+			},
+			{
+				encounterName = "Kel'Thuzad",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.NORMAL_RAID] = true
+				}
+			},
+			{
+				encounterName = "Kel'Thuzad",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.LFR] = true
+				}
+			},
+		},
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.SANCTUM_OF_DOMINATION, i = true}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -1014,6 +1014,50 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 44.3, y = 67.1, n = L["Zelnithop"]}
 		}
 	},
+	["Grappling Gauntlet"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Grappling Gauntlet"],
+		itemId = 186559,
+		spellId = 353638,
+		creatureId = 179220,
+		npcs = {
+			177321,
+			177323,
+			177164,
+			177397,
+			178671,
+			178744,
+			177805,
+			179260,
+			178727,
+			177244,
+			179305,
+			179284,
+			179217,
+			177292,
+			177293,
+			177201,
+			161849,
+			170694,
+			175708,
+			166398,
+			170157,
+			167323,
+			173138,
+			175702,
+			167322,
+			175697,
+			157824,
+		},
+		chance = 200, -- Blind guess
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.KORTHIA},
+			{m = CONSTANTS.UIMAPIDS.THE_MAW},
+			{m = CONSTANTS.UIMAPIDS.ARDENWEALD},
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -957,6 +957,20 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW}
 		}
 	},
+	["Gnashtooth"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Gnashtooth"],
+		itemId = 186538,
+		items = {187028},
+		spellId = 353666,
+		creatureId = 179255,
+		chance = 100, -- Blind guess
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.KORTHIA}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -900,6 +900,20 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW}
 		}
 	},
+	["Fodder"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Fodder"],
+		itemId = 186557,
+		items = {185992},
+		spellId = 353529,
+		creatureId = 179171,
+		chance = 100, -- Blind guess
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.THE_MAW}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -872,6 +872,20 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.SANCTUM_OF_DOMINATION, i = true}
 		}
 	},
+	["Mosscoated Hopper"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Mosscoated Hopper"],
+		itemId = 186541,
+		items = {186650},
+		spellId = 353664,
+		creatureId = 179252,
+		chance = 100, -- Blind guess
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.KORTHIA}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -971,6 +971,20 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.KORTHIA}
 		}
 	},
+	["Amaranthine Stinger"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Amaranthine Stinger"],
+		itemId = 186449,
+		spellId = 353570,
+		creatureId = 179181,
+		npcs = {177979},
+		chance = 25, -- Blind guess
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.THE_MAW, n = L["Gralebboih"]}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/Locales.lua
+++ b/Locales.lua
@@ -1856,6 +1856,8 @@ L["P.O.S.T. Master"] = true
 L["Invasive Buzzer"] = true
 L["Copperback Etherwyrm"] = true
 L["Gnashtooth"] = true
+L["Amaranthine Stinger"] = true
+L["Gralebboih"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1862,6 +1862,7 @@ L["Golden Eye"] = true
 L["Helsworn Soulseeker"] = true
 L["Korthian Specimen"] = true
 L["Zelnithop"] = true
+L["Grappling Gauntlet"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1851,6 +1851,8 @@ L["Mawsworn Minion"] = true
 L["Mosscoated Hopper"] = true
 L["Rook"] = true
 L["Fodder"] = true
+L["Gizmo"] = true
+L["P.O.S.T. Master"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1850,6 +1850,7 @@ L["Irongrasp"] = true
 L["Mawsworn Minion"] = true
 L["Mosscoated Hopper"] = true
 L["Rook"] = true
+L["Fodder"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1847,6 +1847,7 @@ L["Observer Yorik"] = true
 L["Eye of Extermination"] = true
 L["Eye of Allseeing"] = true
 L["Irongrasp"] = true
+L["Mawsworn Minion"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1855,6 +1855,7 @@ L["Gizmo"] = true
 L["P.O.S.T. Master"] = true
 L["Invasive Buzzer"] = true
 L["Copperback Etherwyrm"] = true
+L["Gnashtooth"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1854,6 +1854,7 @@ L["Fodder"] = true
 L["Gizmo"] = true
 L["P.O.S.T. Master"] = true
 L["Invasive Buzzer"] = true
+L["Copperback Etherwyrm"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1845,6 +1845,7 @@ L["Torglluun"] = true
 L["Maw-Ocular Viewfinder"] = true
 L["Observer Yorik"] = true
 L["Eye of Extermination"] = true
+L["Eye of Allseeing"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1846,6 +1846,7 @@ L["Maw-Ocular Viewfinder"] = true
 L["Observer Yorik"] = true
 L["Eye of Extermination"] = true
 L["Eye of Allseeing"] = true
+L["Irongrasp"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1860,6 +1860,8 @@ L["Amaranthine Stinger"] = true
 L["Gralebboih"] = true
 L["Golden Eye"] = true
 L["Helsworn Soulseeker"] = true
+L["Korthian Specimen"] = true
+L["Zelnithop"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1853,6 +1853,7 @@ L["Rook"] = true
 L["Fodder"] = true
 L["Gizmo"] = true
 L["P.O.S.T. Master"] = true
+L["Invasive Buzzer"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1849,6 +1849,7 @@ L["Eye of Allseeing"] = true
 L["Irongrasp"] = true
 L["Mawsworn Minion"] = true
 L["Mosscoated Hopper"] = true
+L["Rook"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1848,6 +1848,7 @@ L["Eye of Extermination"] = true
 L["Eye of Allseeing"] = true
 L["Irongrasp"] = true
 L["Mawsworn Minion"] = true
+L["Mosscoated Hopper"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1844,6 +1844,7 @@ L["Bottled Shade Heart"] = true
 L["Torglluun"] = true
 L["Maw-Ocular Viewfinder"] = true
 L["Observer Yorik"] = true
+L["Eye of Extermination"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1858,6 +1858,8 @@ L["Copperback Etherwyrm"] = true
 L["Gnashtooth"] = true
 L["Amaranthine Stinger"] = true
 L["Gralebboih"] = true
+L["Golden Eye"] = true
+L["Helsworn Soulseeker"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.


### PR DESCRIPTION
This PR includes the following pets from the 9.1 patch
> 
> * [X]  https://www.wowhead.com/item=186555/eye-of-extermination
> * [X]  https://www.wowhead.com/item=186554/eye-of-allseeing
> * [X]  https://www.wowhead.com/item=186541/mosscoated-hopper
> * [X]  https://www.wowhead.com/item=186552/rook
> * [X]  https://www.wowhead.com/item=186558/irongrasp
> * [X]  https://www.wowhead.com/item=186557/fodder
> * [X]  https://www.wowhead.com/item=186550/mawsworn-minion
> * [X]  https://www.wowhead.com/item=186449/amaranthine-stinger
> * [X]  https://www.wowhead.com/item=186534/gizmo
> * [X]  https://www.wowhead.com/item=186547/invasive-buzzer
> * [X]  https://www.wowhead.com/item=186564/golden-eye
> * [X]  https://www.wowhead.com/item=186546/copperback-etherwyrm
> * [X]  https://www.wowhead.com/item=186538/gnashtooth
> * [X]  https://www.wowhead.com/item=186559/grappling-gauntlet
> * [X]  https://www.wowhead.com/item=186542/korthian-specimen
> 

 Potential issues
 - Mawsworn Minion > TooltipNPC here is Kel'thuzad, same NPCId as in Naxxramas

I have created separate issues for those pets that I lack enough data for or are in need of testing before releasing. Also cannot guarantee I haven't missed any, but I've gone by two different lists as a reference.
Should be sufficient enough to close #355.