### PR TITLE
DB: Added Intact Aquilon Core and removed Foresworn Aquilon

### DIFF
--- a/DB/Mounts/Shadowlands.lua
+++ b/DB/Mounts/Shadowlands.lua
@@ -489,21 +489,6 @@ local shadowlandsMounts = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW, n = L["Fallen Charger"]}
 		}
 	},
-	-- ["Foresworn Aquilon"] = {	
-	-- 	cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
-	-- 	type = CONSTANTS.ITEM_TYPES.MOUNT,
-	-- 	method = CONSTANTS.DETECTION_METHODS.NPC,
-	-- 	name = L["Foresworn Aquilon"],
-	-- 	itemId = 186483,
-	-- 	spellId = 353877,
-	-- 	npcs = {180032},
-	-- 	chance = 100, -- Estimate,
-	-- 	requiresCovenant = true,
-	-- 	requiredCovenantID = CONSTANTS.COVENANT_IDS.KYRIAN,
-	-- 	coords = {
-	-- 		{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 47.0, y = 35.5, n = L["Wild Worldcracker"]}
-	-- 	}
-	-- },
 	["Summer Wilderling Harness"] = {	
 		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
 		type = CONSTANTS.ITEM_TYPES.MOUNT,

--- a/DB/Mounts/Shadowlands.lua
+++ b/DB/Mounts/Shadowlands.lua
@@ -489,21 +489,21 @@ local shadowlandsMounts = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW, n = L["Fallen Charger"]}
 		}
 	},
-	["Foresworn Aquilon"] = {	
-		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
-		type = CONSTANTS.ITEM_TYPES.MOUNT,
-		method = CONSTANTS.DETECTION_METHODS.NPC,
-		name = L["Foresworn Aquilon"],
-		itemId = 186483,
-		spellId = 353877,
-		npcs = {180032},
-		chance = 100, -- Estimate,
-		requiresCovenant = true,
-		requiredCovenantID = CONSTANTS.COVENANT_IDS.KYRIAN,
-		coords = {
-			{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 47.0, y = 35.5, n = L["Wild Worldcracker"]}
-		}
-	},
+	-- ["Foresworn Aquilon"] = {	
+	-- 	cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+	-- 	type = CONSTANTS.ITEM_TYPES.MOUNT,
+	-- 	method = CONSTANTS.DETECTION_METHODS.NPC,
+	-- 	name = L["Foresworn Aquilon"],
+	-- 	itemId = 186483,
+	-- 	spellId = 353877,
+	-- 	npcs = {180032},
+	-- 	chance = 100, -- Estimate,
+	-- 	requiresCovenant = true,
+	-- 	requiredCovenantID = CONSTANTS.COVENANT_IDS.KYRIAN,
+	-- 	coords = {
+	-- 		{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 47.0, y = 35.5, n = L["Wild Worldcracker"]}
+	-- 	}
+	-- },
 	["Summer Wilderling Harness"] = {	
 		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
 		type = CONSTANTS.ITEM_TYPES.MOUNT,

--- a/DB/Toys/Shadowlands.lua
+++ b/DB/Toys/Shadowlands.lua
@@ -356,6 +356,21 @@ local shadowlandsToys = {
 			{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 50.2, y = 75.4, n = L["Observer Yorik"]}
 		}
 	},
+	["Intact Aquilon Core"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Intact Aquilon Core"],
+		itemId = 187282,
+		npcs = {180032},
+		chance = 100, -- Blind guess
+		unique = true,
+		requiresCovenant = true,
+		requiredCovenantID = CONSTANTS.COVENANT_IDS.KYRIAN,
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 47.0, y = 35.5, n = L["Wild Worldcracker"]}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.toys, shadowlandsToys)

--- a/Locales.lua
+++ b/Locales.lua
@@ -1865,6 +1865,7 @@ L["Zelnithop"] = true
 L["Grappling Gauntlet"] = true
 L["Squibbles"] = true
 L["This bag is rewarded for completing the pet battle daily offered by Anthea at the Temple of the White Tiger in Kun-Lai Summit."] = true
+L["Intact Aquilon Core"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1823,7 +1823,6 @@ L["Crimson Shardhide"] = true
 L["Malbog"] = true
 L["Fallen Charger's Reins"] = true
 L["Fallen Charger"] = true
-L["Foresworn Aquilon"] = true
 L["Wild Worldcracker"] = true
 L["Summer Wilderling Harness"] = true
 L["Escaped Wilderling"] = true


### PR DESCRIPTION
Further research points that this mount is obtained from a quest reward rather than dropping from the NPC. Added the quest item to the database instead, similar to the Necrolord and Venthyr one.

Video proof: [https://www.youtube.com/watch?v=7MN3dM5NFlI](https://www.youtube.com/watch?v=7MN3dM5NFlI)