### PR TITLE
DB: Added the two toys from Zooval's Vault

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1434,6 +1434,23 @@ function R:OnEvent(event, ...)
 			end
 		end
 
+		-- Handle opening Zovaal's Vault (The Maw, Shadowlands treasure for Personal Ball and Chain & Jailer's Cage
+		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Zovaal's Vault"]) then
+			local names = {"Personal Ball and Chain", "Jailer's Cage"}
+			Rarity:Debug("Detected Opening on " .. L["Zovaal's Vault"] .. " (method = SPECIAL)")
+			for _, name in pairs(names) do
+				local v = self.db.profile.groups.items[name]
+				if v and type(v) == "table" and v.enabled ~= false then
+					if v.attempts == nil then
+						v.attempts = 1
+					else
+						v.attempts = v.attempts + 1
+					end
+					self:OutputAttempts(v)
+				end
+			end
+		end
+
 		-- Handle opening Pile of Coins
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Pile of Coins"]) then
 			local names = {"Armored Vaultbot"}

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -246,5 +246,6 @@ R.opennodes = {
 	[L["Gift of Thenios"]] = true,
 	[L["Hidden Hoard"]] = true,
 	[L["Memorial Offerings"]] = true,
-	[L["Treasure of Courage"]] = true
+	[L["Treasure of Courage"]] = true,
+	[L["Zovaal's Vault"]] = true
 }

--- a/DB/Toys/Shadowlands.lua
+++ b/DB/Toys/Shadowlands.lua
@@ -386,6 +386,32 @@ local shadowlandsToys = {
 			{m = CONSTANTS.UIMAPIDS.KORTHIA, x = 33.49, y = 39.54, n = L["Escaped Wilderling"]}
 		}
 	},
+	["Personal Ball and Chain"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+		name = L["Personal Ball and Chain"],
+		itemId = 187113,
+		chance = 10, -- Estimate,
+		sourceText = L["This treasure can only be found within the rift phase of The Maw."],
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.THE_MAW}
+		}
+	},
+	["Jailer's Cage"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+		name = L["Jailer's Cage"],
+		itemId = 187416,
+		chance = 15, -- Estimate,
+		sourceText = L["This treasure can only be found within the rift phase of The Maw."],
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.THE_MAW}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.toys, shadowlandsToys)

--- a/Locales.lua
+++ b/Locales.lua
@@ -1868,6 +1868,10 @@ L["Grappling Gauntlet"] = true
 L["Squibbles"] = true
 L["This bag is rewarded for completing the pet battle daily offered by Anthea at the Temple of the White Tiger in Kun-Lai Summit."] = true
 L["Intact Aquilon Core"] = true
+L["Personal Ball and Chain"] = true
+L["This treasure can only be found within the rift phase of The Maw."] = true
+L["Jailer's Cage"] = true
+L["Zovaal's Vault"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.


### PR DESCRIPTION
As advertised in the title, I have added the two toys found in Zooval's Vault in the rift phase of the maw.
[https://www.wowhead.com/item=187113/personal-ball-and-chain](https://www.wowhead.com/item=187113/personal-ball-and-chain)
[https://www.wowhead.com/item=187416/jailers-cage](https://www.wowhead.com/item=187416/jailers-cage)

This PR closes #361 