### PR TITLE
DB: Updated drop rate for Fallen Charger

### DIFF
--- a/DB/Mounts/Shadowlands.lua
+++ b/DB/Mounts/Shadowlands.lua
@@ -485,7 +485,7 @@ local shadowlandsMounts = {
 		itemId = 186659,
 		spellId = 354353,
 		npcs = {179460},
-		chance = 100, -- Estimate,
+		chance = 7,
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW, n = L["Fallen Charger"]}
 		}


### PR DESCRIPTION
With todays [hotfix](https://worldofwarcraft.com/en-gb/news/23691036/hotfixes-july-15-2021), Fallen Charger has a new drop rate of about 15%