### PR TITLE
Add streamlined Profiling API

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -753,6 +753,19 @@ function R:OnChatCommand(input)
 			self.db.profile.enableProfiling = true
 			self:Print(L["Profiling ON"])
 		end
+	elseif strlower(input) == "tinspect" then --  TODO Document it?
+
+		local isLoading, isLoaded = IsAddOnLoaded("Blizzard_DebugTools")
+		if not isLoaded then
+			Rarity:Debug("Loading Blizzard_DebugTools (required to use the Table Inspector)")
+			local success, reason = LoadAddOn("Blizzard_DebugTools")
+			if not success then
+				Rarity:Debug("Failed to open Table Inspector (Blizzard_DebugTools could not be loaded)")
+				return
+			end
+		end
+		local tableInspectorInstance = _G["DisplayTableInspectorWindow"](Rarity.Profiling.accumulatedTimes, "Rarity Profiling Data")
+		tableInspectorInstance:SetDynamicUpdates(true)
 	else
 		LoadAddOn("Rarity_Options")
 		if R.optionsFrame then

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -754,18 +754,7 @@ function R:OnChatCommand(input)
 			self:Print(L["Profiling ON"])
 		end
 	elseif strlower(input) == "tinspect" then --  TODO Document it?
-
-		local isLoading, isLoaded = IsAddOnLoaded("Blizzard_DebugTools")
-		if not isLoaded then
-			Rarity:Debug("Loading Blizzard_DebugTools (required to use the Table Inspector)")
-			local success, reason = LoadAddOn("Blizzard_DebugTools")
-			if not success then
-				Rarity:Debug("Failed to open Table Inspector (Blizzard_DebugTools could not be loaded)")
-				return
-			end
-		end
-		local tableInspectorInstance = _G["DisplayTableInspectorWindow"](Rarity.Profiling.accumulatedTimes, "Rarity Profiling Data")
-		tableInspectorInstance:SetDynamicUpdates(true)
+		Rarity.Profiling:InspectAccumulatedTimes()
 	else
 		LoadAddOn("Rarity_Options")
 		if R.optionsFrame then

--- a/Core/Profiling.lua
+++ b/Core/Profiling.lua
@@ -32,6 +32,22 @@ function Profiling:HasAccumulatedTime(label)
 	return self.accumulatedTimes[label] ~= nil
 end
 
+function Profiling:InspectAccumulatedTimes()
+	-- TODO: If clicked multiple times, it will open a new instance. But I guess we don't really care to fix this?
+	local isLoading, isLoaded = IsAddOnLoaded("Blizzard_DebugTools")
+	if not isLoaded then
+		Rarity:Debug("Loading Blizzard_DebugTools (required to use the Table Inspector)")
+		local success, reason = LoadAddOn("Blizzard_DebugTools")
+		if not success then
+			Rarity:Debug("Failed to open Table Inspector (Blizzard_DebugTools could not be loaded)")
+			return
+		end
+	end
+	-- This can't be cached as the addon isn't loaded automatically, and the global DisplayTableInspectorWindow won't be available
+	local tableInspectorInstance = _G["DisplayTableInspectorWindow"](self.accumulatedTimes, "Rarity Profiling Data")
+	tableInspectorInstance:SetDynamicUpdates(true)
+end
+
 function Profiling:ResetAccumulatedTime(label)
 	self.accumulatedTimes[label] = 0
 end

--- a/Core/Profiling.lua
+++ b/Core/Profiling.lua
@@ -1,8 +1,71 @@
 local _, addonTable = ...
 
-local Profiling = {}
+local Profiling = {
+	DEFAULT_TIMER_LABEL = "Default",
+	activeTimers = {},
+	accumulatedTimes = {}
+}
 
--- What's with this file? Looks like the profiling code should go there, but right now it is all over the place
+function Profiling:StartTimer(label)
+	if not self:IsProfilingEnabled() then
+		return
+	end
+
+	label = label or self.DEFAULT_TIMER_LABEL
+
+	if self.activeTimers[label] then
+		Rarity:Debug("Failed to start timer %s (already running)", label) -- Should be a NOTICE or similar
+		return
+	end
+
+	local startTime = self:GetCurrentTimeInMilliseconds()
+	self.activeTimers[label] = startTime
+end
+
+local GetTimePreciseSec = _G.GetTimePreciseSec
+local MS_PER_SECOND = 1000
+
+function Profiling:GetCurrentTimeInMilliseconds()
+	return GetTimePreciseSec() * MS_PER_SECOND
+	-- Relying on debugprofilestop() is risky, as it could be reset globally via debugprofilestart()
+	-- return debugprofilestop()
+end
+
+function Profiling:EndTimer(label)
+	if not self:IsProfilingEnabled() then
+		return
+	end
+
+	label = label or self.DEFAULT_TIMER_LABEL
+
+	local startTime = self.activeTimers[label]
+
+	if not startTime then
+		Rarity:Debug("Failed to end timer %s (no such timer is active)", label)
+		return
+	end
+
+	local endTime = self:GetCurrentTimeInMilliseconds()
+	local elapsedTimeInMilliseconds = endTime - startTime
+
+	self.activeTimers[label] = nil
+
+	Rarity:ProfileDebug(format("%s: %.2f ms", label, elapsedTimeInMilliseconds))
+end
+
+function Profiling:GetTimer(label)
+	if not self:IsProfilingEnabled() then
+		return
+	end
+
+	label = label or self.DEFAULT_TIMER_LABEL
+
+	return self.activeTimers[label]
+end
+
+function Profiling:IsProfilingEnabled()
+	return Rarity.db.profile.enableProfiling
+end
 
 Rarity.Profiling = Profiling
 return Profiling

--- a/Core/Profiling.lua
+++ b/Core/Profiling.lua
@@ -61,6 +61,7 @@ function Profiling:ResetAccumulatedTime(label)
 		return
 	end
 
+	Rarity:Debug("Reset accumulated profiling data for label %s", label)
 	self.accumulatedTimes[label] = 0
 end
 

--- a/Core/Profiling.lua
+++ b/Core/Profiling.lua
@@ -2,6 +2,7 @@ local _, addonTable = ...
 
 local Profiling = {
 	DEFAULT_TIMER_LABEL = "Default",
+	isTimerRunning = false,
 	activeTimers = {},
 	accumulatedTimes = {}
 }
@@ -20,6 +21,31 @@ function Profiling:StartTimer(label)
 
 	local startTime = self:GetCurrentTimeInMilliseconds()
 	self.activeTimers[label] = startTime
+
+	-- If it's is the first time this label was used, we'll initialize the total implicitly here
+	if not self:HasAccumulatedTime(label) then
+		self:ResetAccumulatedTime(label)
+	end
+end
+
+function Profiling:HasAccumulatedTime(label)
+	return self.accumulatedTimes[label] ~= nil
+end
+
+function Profiling:ResetAccumulatedTime(label)
+	self.accumulatedTimes[label] = 0
+end
+
+function Profiling:GetAccumulatedTime(label)
+	return self.accumulatedTimes[label]
+end
+
+function Profiling:AccumulateTime(label, timeInMilliseconds)
+	if not self:HasAccumulatedTime(label) then
+		self:ResetAccumulatedTime(label)
+	end
+
+	self.accumulatedTimes[label] = self.accumulatedTimes[label] + timeInMilliseconds
 end
 
 local GetTimePreciseSec = _G.GetTimePreciseSec
@@ -47,6 +73,8 @@ function Profiling:EndTimer(label)
 
 	local endTime = self:GetCurrentTimeInMilliseconds()
 	local elapsedTimeInMilliseconds = endTime - startTime
+
+	self:AccumulateTime(label, elapsedTimeInMilliseconds)
 
 	self.activeTimers[label] = nil
 

--- a/Core/Profiling.lua
+++ b/Core/Profiling.lua
@@ -1,5 +1,13 @@
 local _, addonTable = ...
 
+-- Upvalues
+--- WOW API
+local IsAddOnLoaded = IsAddOnLoaded
+local LoadAddOn = LoadAddOn
+--- Lua API
+local table_wipe = table.wipe
+local pairs = pairs
+
 local Profiling = {
 	DEFAULT_TIMER_LABEL = "Default",
 	isTimerRunning = false,

--- a/Core/Profiling.lua
+++ b/Core/Profiling.lua
@@ -60,6 +60,15 @@ function Profiling:ResetAccumulatedTime(label)
 	self.accumulatedTimes[label] = 0
 end
 
+function Profiling:ResetAccumulatedTimes()
+	Rarity:Debug("Reset ALL accumulated profiling data")
+
+	for label, time in pairs(self.accumulatedTimes) do
+		-- If we just re-assign the table, the Table Inspector's dynamic updates will stop working and we have to re-open it (I think)
+		self:ResetAccumulatedTime(label)
+	end
+end
+
 function Profiling:GetAccumulatedTime(label)
 	return self.accumulatedTimes[label]
 end

--- a/Core/Profiling.lua
+++ b/Core/Profiling.lua
@@ -57,6 +57,10 @@ function Profiling:InspectAccumulatedTimes()
 end
 
 function Profiling:ResetAccumulatedTime(label)
+	if not label then
+		return
+	end
+
 	self.accumulatedTimes[label] = 0
 end
 

--- a/Locales.lua
+++ b/Locales.lua
@@ -2,6 +2,11 @@ local L
 L = LibStub("AceLocale-3.0"):NewLocale("Rarity", "enUS", true)
 
 -- L["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] = true
+L["Displays accumulated profiling data for the current session."] = true
+L["Show profiling data"] = true
+L["This is merely a shortcut introduced to make life easier for developers, and as a regular player you can safely ignore it."] = true
+L["Deletes accumulated profiling data for the current session."] = true
+L["Reset profiling data"] = true
 L["Sorting is disabled"] = true
 L["Disable sorting inside the main window. Can be used to troubleshoot performance issues."] = true
 L["Disable sorting"] = true

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -1671,8 +1671,28 @@ function R:PrepareOptions()
 							self.db.profile.sortMode = C.SORT_METHODS.SORT_NONE
 						end
 					},
-				},
-			},
+					showAccumulatedTimes = {
+						type = "execute",
+						order = newOrder(),
+						-- width = "full",
+						name = L["Show profiling data"],
+						desc = L["Displays accumulated profiling data for the current session."] .. " " ..  L["This is merely a shortcut introduced to make life easier for developers, and as a regular player you can safely ignore it."],
+						func = function(info, val)
+							Rarity.Profiling:InspectAccumulatedTimes()
+						end
+					},
+					resetAccumulatedTimes = {
+						type = "execute",
+						order = newOrder(),
+						-- width = "full",
+						name = L["Reset profiling data"],
+						desc = L["Deletes accumulated profiling data for the current session."] .. " " ..  L["This is merely a shortcut introduced to make life easier for developers, and as a regular player you can safely ignore it."],
+						func = function(info, val)
+							Rarity.Profiling:ResetAccumulatedTimes()
+						end
+					},
+				}
+			}
 		}
 	}
 end -- function R:PrepareOptions()


### PR DESCRIPTION
Extracted the relevant parts from #398 

There are two main features (related) here:

* A streamlined ``Profiling`` API that supports nested groups, inspired by the profiling parts of the ``console`` API in browser environments
* An addition to the Options UI that allows accessing and resetting the profiling data