### PR TITLE
Added Adamant Vaults Cell

### DIFF
--- a/DB/Toys/Shadowlands.lua
+++ b/DB/Toys/Shadowlands.lua
@@ -412,6 +412,21 @@ local shadowlandsToys = {
 			{m = CONSTANTS.UIMAPIDS.THE_MAW}
 		}
 	},
+	["Adamant Vaults Cell"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Adamant Vaults Cell"],
+		isToy = true,
+		itemId = 187417,
+		npcs = {176578, 179526, 179433},
+		chance = 11, -- Blind guess
+		unique = true,
+		sourceText = L["This item can only drop in the Adamant Vaults section of Torghast."],
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.TORGHAST}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.toys, shadowlandsToys)

--- a/Locales.lua
+++ b/Locales.lua
@@ -1895,6 +1895,8 @@ L["Razorwing Nest"] = true
 L["Darkmaul"] = true
 L["The Mawshrooms are obtained from treasure nodes called Invasive Mawshroom in Korthia."] = true
 L["Darkmaul is obtained by feeding a friendly NPC in Korthia called Darkmaul 10 Tasty Mawshroom"] = true
+L["Adamant Vaults Cell"] = true
+L["This item can only drop in the Adamant Vaults section of Torghast."] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.


### PR DESCRIPTION
It's long overdue, but I finally added the [Adamant Vaults Cell](https://www.wowhead.com/item=187417/adamant-vaults-cell) from Adamant Vaults in Torghast. Luckily the bosses seem unique to this particular subzone, so no fancy logic was required. This closes #360.