### PR TITLE
Gilded Darknight

### DIFF
--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -1077,6 +1077,21 @@ local shadowlandsPets = {
 			{m = CONSTANTS.UIMAPIDS.KUNLAI_SUMMIT}
 		}
 	},
+	["Gilded Darknight"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Gilded Darknight"],
+		itemId = 186549,
+		spellId = 353656,
+		creatureId = 179239,
+		npcs = {179526, 176578, 179433},
+		chance = 7,
+		sourceText = L["This pet can only drop in the Adamant Vaults section of Torghast."],
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.TORGHAST}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, shadowlandsPets)

--- a/DB/Pets/Shadowlands.lua
+++ b/DB/Pets/Shadowlands.lua
@@ -1087,7 +1087,7 @@ local shadowlandsPets = {
 		creatureId = 179239,
 		npcs = {179526, 176578, 179433},
 		chance = 7,
-		sourceText = L["This pet can only drop in the Adamant Vaults section of Torghast."],
+		sourceText = L["This item can only drop in the Adamant Vaults section of Torghast."],
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.TORGHAST}
 		}

--- a/Locales.lua
+++ b/Locales.lua
@@ -1898,7 +1898,6 @@ L["Darkmaul is obtained by feeding a friendly NPC in Korthia called Darkmaul 10 
 L["Adamant Vaults Cell"] = true
 L["This item can only drop in the Adamant Vaults section of Torghast."] = true
 L["Gilded Darknight"] = true
-L["This pet can only drop in the Adamant Vaults section of Torghast."] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.

--- a/Locales.lua
+++ b/Locales.lua
@@ -1897,6 +1897,8 @@ L["The Mawshrooms are obtained from treasure nodes called Invasive Mawshroom in 
 L["Darkmaul is obtained by feeding a friendly NPC in Korthia called Darkmaul 10 Tasty Mawshroom"] = true
 L["Adamant Vaults Cell"] = true
 L["This item can only drop in the Adamant Vaults section of Torghast."] = true
+L["Gilded Darknight"] = true
+L["This pet can only drop in the Adamant Vaults section of Torghast."] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.


### PR DESCRIPTION
Added another easy one. [Gilded Darknight](https://www.wowhead.com/item=186549/gilded-darknight), a pet from Adamant Vaults in Torghast. This closes #366 :)