### PR TITLE
Add tracking for Shaded Judgment Stone

### DIFF
--- a/DB/Toys/Shadowlands.lua
+++ b/DB/Toys/Shadowlands.lua
@@ -479,6 +479,27 @@ local shadowlandsToys = {
 			{m = CONSTANTS.UIMAPIDS.REVENDRETH}
 		}
 	},
+	["Shaded Judgment Stone"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Shaded Judgment Stone"],
+		isToy = true,
+		itemId = 187174,
+		npcs = {
+			179913,
+			179608,
+			179914,
+			179911,
+			179853
+		},
+		chance = 100, -- Blind guess
+		sourceText = L["This item can only drop in the rift phase of Korthia and The Maw."],
+		coords = {
+			{m = CONSTANTS.UIMAPIDS.KORTHIA},
+			{m = CONSTANTS.UIMAPIDS.THE_MAW}
+		}
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.toys, shadowlandsToys)

--- a/Locales.lua
+++ b/Locales.lua
@@ -1902,6 +1902,8 @@ L["Steward's First Feather"] = true
 L["Apprentice Slimemancer's Boots"] = true
 L["Sparkle Wings"] = true
 L["Tome of Small Sins"] = true
+L["Shaded Judgment Stone"] = true
+L["This item can only drop in the rift phase of Korthia and The Maw."] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.


### PR DESCRIPTION
Added the toy [Shaded Judgment Stone](https://www.wowhead.com/item=187174/shaded-judgment-stone). As mentioned in the issue #359, this item has been a bit buggy in the beginning of the patch, but does now drop - but Wowhead data is likely affected by the late and buggy appearance. Added the confirmed sources with a guesstimate droprate.

This closes #359.