### PR TITLE
Flagged Sharkbait's Favorite Crackers as soloable

### DIFF
--- a/DB/Mounts/BattleForAzeroth.lua
+++ b/DB/Mounts/BattleForAzeroth.lua
@@ -571,7 +571,6 @@ local bfaMounts = {
 		npcs = {126983},
 		statisticId = {12752},
 		chance = 200,
-		equalOdds = true,
 		instanceDifficulties = {[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true},
 		lockoutDetails = {
 			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
@@ -582,7 +581,6 @@ local bfaMounts = {
 				}
 			}
 		},
-		groupSize = 5,
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.FREEHOLD, i = true}
 		}


### PR DESCRIPTION
As per title, [Sharkbait's Favorite Crackers](https://www.wowhead.com/item=159842/sharkbaits-favorite-crackers) is easily soloable by anyone these days, so removed groupSize and equalOdds on it