### PR TITLE
Adjusted drop rate for Smolderheart

### DIFF
--- a/DB/Toys/Shadowlands.lua
+++ b/DB/Toys/Shadowlands.lua
@@ -55,7 +55,7 @@ local shadowlandsToys = {
 		name = L["Smolderheart"],
 		itemId = 180873,
 		npcs = {160857},
-		chance = 25,
+		chance = 20,
 		questId = {58263},
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.REVENDRETH, x = 34.08, y = 55.47, n = L["Sire Ladinas"]}


### PR DESCRIPTION
[Smolderheart](https://www.wowhead.com/item=180873/smolderheart) was listed with 4% drop - Wowhead says 5%. Small annoyance, but fixing as I am grinding it atm