### PR TITLE
Added tracking for Bonehoof Tauralus

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -110,7 +110,7 @@ local GetMapInfo = _G.C_Map.GetMapInfo
 local C_Timer = _G.C_Timer
 local IsSpellKnown = _G.IsSpellKnown
 local CombatLogGetCurrentEventInfo = _G.CombatLogGetCurrentEventInfo
-local IsQuestFlaggedCompleted = _G.IsQuestFlaggedCompleted
+local IsQuestFlaggedCompleted = _G.C_QuestLog.IsQuestFlaggedCompleted
 local C_Covenants = _G.C_Covenants
 
 local COMBATLOG_OBJECT_AFFILIATION_MINE = _G.COMBATLOG_OBJECT_AFFILIATION_MINE
@@ -739,6 +739,15 @@ function R:IsAttemptAllowed(item)
 			)
 		)
 		return false
+	end
+
+	-- If any prerequisite quests exist, check if they are all completed
+	if item.requiresCompletedQuestId and type(item.requiresCompletedQuestId) == "table" then
+		for key, questId in pairs(item.requiresCompletedQuestId) do
+			if not IsQuestFlaggedCompleted(questId) then
+				return false
+			end
+		end
 	end
 
 	-- No valid instance difficulty configuration; allow (this needs to be the second-to-last check)

--- a/DB/Item.lua
+++ b/DB/Item.lua
@@ -34,6 +34,7 @@ local Item = {
 		unique = false,
 		worldQuestId = false,
 		pickpocket = false,
+		requiresCompletedQuestId = false,
 		-- Populated fields (SavedVariables)
 		attempts = false,
 		lastAttempts = false,

--- a/DB/Mounts/Shadowlands.lua
+++ b/DB/Mounts/Shadowlands.lua
@@ -30,6 +30,7 @@ local shadowlandsMounts = {
 		spellId = 332457,
 		npcs = { 162586 },
 		chance = 100,
+		questId = {58783},
 		coords = {
 			{ m = CONSTANTS.UIMAPIDS.MALDRAXXUS, x = 44.2, y = 51.2, n = L["Tahonta"] },
 		},

--- a/DB/Mounts/Shadowlands.lua
+++ b/DB/Mounts/Shadowlands.lua
@@ -21,21 +21,23 @@ local shadowlandsMounts = {
 		requiresCovenant = true,
 		requiredCovenantID = CONSTANTS.COVENANT_IDS.VENTHYR
 	},
-	-- ["Bonehoof Tauralus"] = { -- NYI as of 21/01/2021 ?
-	-- 	cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
-	-- 	type = CONSTANTS.ITEM_TYPES.MOUNT,
-	-- 	method = CONSTANTS.DETECTION_METHODS.NPC,
-	-- 	name = L["Bonehoof Tauralus"],
-	-- 	itemId = 182075,
-	-- 	spellId = 332457,
-	-- 	npcs = { 162586 },
-	-- 	chance = 100,
-	-- 	coords = {
-	-- 		{ m = CONSTANTS.UIMAPIDS.MALDRAXXUS, x = 44.2, y = 51.2, n = L["Tahonta"] },
-	-- 	},
-	-- 	requiresCovenant = true,
-	-- 	requiredCovenantID = CONSTANTS.COVENANT_IDS.NECROLORD
-	-- },
+	["Bonehoof Tauralus"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,
+		type = CONSTANTS.ITEM_TYPES.MOUNT,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Bonehoof Tauralus"],
+		itemId = 182075,
+		spellId = 332457,
+		npcs = { 162586 },
+		chance = 100,
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.MALDRAXXUS, x = 44.2, y = 51.2, n = L["Tahonta"] },
+		},
+		requiresCovenant = true,
+		requiredCovenantID = CONSTANTS.COVENANT_IDS.NECROLORD,
+		sourceText = L["This mount can only drop while having the Abomination Stitching construct Neena as your active companion."],
+		requiresCompletedQuestId = { 57603 } -- This quest represents having the companion Neena summoned.
+	},
 
 	["Hopecrusher Gargon"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.SHADOWLANDS,

--- a/Locales.lua
+++ b/Locales.lua
@@ -1904,6 +1904,7 @@ L["Sparkle Wings"] = true
 L["Tome of Small Sins"] = true
 L["Shaded Judgment Stone"] = true
 L["This item can only drop in the rift phase of Korthia and The Maw."] = true
+L["This mount can only drop while having the Abomination Stitching construct Neena as your active companion."] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.


### PR DESCRIPTION
Finally got around to looking at this again, and with the new information presented, I have implemented tracking for this badboy. Getting a valid attempt requires having a quest flagged as completed, as this represents having the companion active.

This closes #343.