### PR TITLE
Flagged "other" covenant items as unavailable

### DIFF
--- a/Core/GUI/MainWindow.lua
+++ b/Core/GUI/MainWindow.lua
@@ -8,6 +8,7 @@ local CONSTANTS = addonTable.constants
 local GetBestMapForUnit = C_Map.GetBestMapForUnit
 local IsWorldQuestActive = C_TaskQuest.IsActive
 local IsQuestFlaggedCompleted = _G.C_QuestLog.IsQuestFlaggedCompleted
+local C_Covenants = _G.C_Covenants
 
 local FormatTime = Rarity.Utils.PrettyPrint.FormatTime
 local sort2 = Rarity.Utils.Sorting.sort2
@@ -1060,6 +1061,13 @@ local function addGroup(group, requiresGroup)
 						if v.pickpocket then
 							local class, classFileName = UnitClass("player")
 							if classFileName ~= "ROGUE" then
+								status = colorize(L["Unavailable"], gray)
+							end
+						end
+
+						if v.requiresCovenant and v.requiredCovenantID ~= nil then
+							local activeCovenantID = C_Covenants.GetActiveCovenantID()
+							if (activeCovenantID ~= v.requiredCovenantID) then
 								status = colorize(L["Unavailable"], gray)
 							end
 						end


### PR DESCRIPTION
As mentioned in #345, items that require players to be of a specific covenant to be obtained are effectively unavailable if the player is currently in favor of another covenant. Added some code to flag these items as such if that is the case.

This closes #345 if merged.