### PR TITLE
Updates for Underrot Crawg Harness

### DIFF
--- a/DB/Mounts/BattleForAzeroth.lua
+++ b/DB/Mounts/BattleForAzeroth.lua
@@ -596,9 +596,7 @@ local bfaMounts = {
 		tooltipNpcs = {133007},
 		statisticId = {12745},
 		chance = 200,
-		equalOdds = true,
 		instanceDifficulties = {[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true},
-		groupSize = 5,
 		lockoutDetails = {
 			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
 			{

--- a/DB/Mounts/BattleForAzeroth.lua
+++ b/DB/Mounts/BattleForAzeroth.lua
@@ -599,6 +599,15 @@ local bfaMounts = {
 		equalOdds = true,
 		instanceDifficulties = {[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true},
 		groupSize = 5,
+		lockoutDetails = {
+			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
+			{
+				encounterName = "Unbound Abomination",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true
+				}
+			}
+		},
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.THE_UNDERROT, i = true}
 		}


### PR DESCRIPTION
[Underrot Crawg Harness](https://www.wowhead.com/item=160829/underrot-crawg-harness) is soloable after the changes to legacy loot for BFA dungeons. Removed the groupSize etc for this.
Also added defeat detection while I was at it