### PR TITLE
Updates for Mummified Raptor Skull

### DIFF
--- a/DB/Mounts/BattleForAzeroth.lua
+++ b/DB/Mounts/BattleForAzeroth.lua
@@ -614,9 +614,7 @@ local bfaMounts = {
 		tooltipNpcs = {136160},
 		statisticId = {12763},
 		chance = 200,
-		equalOdds = true,
 		instanceDifficulties = {[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true},
-		groupSize = 5,
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.KINGS_REST, i = true}
 		}

--- a/DB/Mounts/BattleForAzeroth.lua
+++ b/DB/Mounts/BattleForAzeroth.lua
@@ -615,6 +615,15 @@ local bfaMounts = {
 		statisticId = {12763},
 		chance = 200,
 		instanceDifficulties = {[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true},
+		lockoutDetails = {
+			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
+			{
+				encounterName = "King Dazar",
+				instanceDifficulties = {
+					[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true
+				}
+			}
+		},
 		coords = {
 			{m = CONSTANTS.UIMAPIDS.KINGS_REST, i = true}
 		}


### PR DESCRIPTION
[Mummified Raptor Skull](https://www.wowhead.com/item=159921/mummified-raptor-skull) is soloable after the changes to legacy loot for BFA dungeons. Removed the groupSize etc for this.
Also added defeat detection while I was at it