### PR TITLE
Set up GitHub Actions workflow to publish releases via the BigWigs packager

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,26 @@
+name: Packaging
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 100
+
+      - name: Publish new release
+        uses: BigWigsMods/packager@master
+        env:
+          CF_API_KEY: ${{ secrets.CURSEFORGE_API_TOKEN }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.pkgmeta
+++ b/.pkgmeta
@@ -77,7 +77,7 @@ externals:
     Libs/AceSerializer-3.0:
         url: https://repos.wowace.com/wow/ace3/trunk/AceSerializer-3.0
         tag: latest
-            
+
 tools-used:
     - libdatabroker-1-1
     - addon-loader
@@ -89,3 +89,4 @@ ignore:
  - README.MD
  - Changes.lua
  - .luacheckrc
+ - autoformat.sh

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -3,6 +3,7 @@
 ## X-Min-Interface: 90105
 ## Title: Rarity
 ## Version: 1.0 (@project-version@)
+## X-Curse-Project-ID: 30801
 
 ## Notes: Tracks rare drops, including companions and mounts
 ## Notes-ruRU: @localization(locale="ruRU", key="Notes", namespace="ToC - Table of Contents")@


### PR DESCRIPTION
This replaces the Webhooks-based workflow, since it doesn't support platforms other than CurseForge.