### PR TITLE
Fix an incorrect negation in the TSM module

### DIFF
--- a/Core/Interoperability/TradeSkillMaster/AuctionDB.lua
+++ b/Core/Interoperability/TradeSkillMaster/AuctionDB.lua
@@ -39,7 +39,7 @@ end
 -- @param priceSource A string representing the price source
 -- @return True if TSM recognized the price source; false (nil) otherwise
 function AuctionDB:IsValidPriceSource(priceSource)
-	if not type(priceSource) == "string" then
+	if type(priceSource) ~= "string" then
 		return
 	end
 


### PR DESCRIPTION
That's clearly an oversight/rookie mistake. It must have been many years since I wrote that code, though I remember making this particular mistake before...

Anyway: Seems like luacheck recently added the capability for detecting this type of error, so the CI is now failing (as it should)!. However, my local version was outdated and subsequently didn't raise the issue, which is why it went unnoticed for so long.