### PR TITLE
Update the luaformat workflow to fix a git protocol error

### DIFF
--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -22,13 +22,13 @@ jobs:
         run: sudo apt-get install luajit libluajit-5.1-dev
 
       - name: Download LuaRocks
-        run: wget https://luarocks.org/releases/luarocks-3.7.0.tar.gz
+        run: wget https://luarocks.org/releases/luarocks-3.9.0.tar.gz
 
       - name: Unpack LuaRocks release
-        run: tar zxpf luarocks-3.7.0.tar.gz
+        run: tar zxpf luarocks-3.9.0.tar.gz
 
       - name: Install LuaRocks
-        run: cd luarocks-3.7.0 && ./configure && make && sudo make install
+        run: cd luarocks-3.9.0 && ./configure && make && sudo make install
 
       - name: Install lua-formatter
         run: sudo luarocks install --server=https://luarocks.org/dev luaformatter


### PR DESCRIPTION
Apparently GitHub completely removed support for standard git protocols, and luarocks can no longer download the formatter as a result.

Edit: Resolved by using a more recent luarocks version in the workflow.