### PR TITLE
Living infernal core updates

### DIFF
--- a/DB/Mounts/Legion.lua
+++ b/DB/Mounts/Legion.lua
@@ -329,6 +329,13 @@ local legionMounts = {
 		blackMarket = true,
 		statisticId = { 10979, 10980, 10978 },
 		coords = { { m = 772, i = true } },
+		lockoutDetails = {
+			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
+			{ encounterName = "Gul'dan", instanceDifficulties = { [CONSTANTS.INSTANCE_DIFFICULTIES.NORMAL_RAID] = true } },
+			{ encounterName = "Gul'dan", instanceDifficulties = { [CONSTANTS.INSTANCE_DIFFICULTIES.HEROIC_RAID] = true } },
+			{ encounterName = "Gul'dan", instanceDifficulties = { [CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_RAID] = true } },
+
+		},
 	},
 	["Midnight's Eternal Reins"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.LEGION,

--- a/DB/Mounts/Legion.lua
+++ b/DB/Mounts/Legion.lua
@@ -323,6 +323,7 @@ local legionMounts = {
 		tooltipNpcs = {
 			105503,
 			104154, -- Gul'dan (normal)
+			111022, -- The Demon Within (Mythic only)
 		},
 		chance = 100,
 		blackMarket = true,


### PR DESCRIPTION
Following up on a previous Discord conversation and decided to add another one of the missing defeat detections from Legion raids, Living Infernal Core. Also added a missing tooltipNPC while I was at it. Did a quick run-through and seems to work just fine