### PR TITLE
Add GameTooltip hooks for Quest Rewards

### DIFF
--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -278,11 +278,8 @@ _G.GameTooltip:HookScript("OnTooltipSetUnit", function(self)
 	end
 end)
 
--- TOOLTIP: ITEMS IN INVENTORY
-
-hooksecurefunc(GameTooltip, "SetBagItem", function(self, bag, slot)
+local function processItem(id)
 	local blankAdded = false
-	local id = GetContainerItemID(bag, slot)
 	if id then
 		local item
 		local rarityAdded = false
@@ -381,4 +378,43 @@ hooksecurefunc(GameTooltip, "SetBagItem", function(self, bag, slot)
 			end
 		end
 	end
+end
+
+local function processItemString(itemString)
+	if itemString then
+		local id = itemString:match("item:(%d+):")
+		processItem(tonumber(id))
+	end
+end
+
+-- TOOLTIP: ITEMS IN INVENTORY
+
+hooksecurefunc(GameTooltip, "SetBagItem", function(self, bag, slot)
+	local id = GetContainerItemID(bag, slot)
+	processItem(id)
 end)
+
+-- TOOLTIP: ITEMS FROM QUESTGIVERS
+
+hooksecurefunc(GameTooltip, "SetQuestItem", function(self, type, index)
+	local itemString = GetQuestItemLink(type, index)
+	processItemString(itemString)
+end)
+
+-- TOOLTIP: ITEMS FROM QUEST LOG
+
+hooksecurefunc(GameTooltip, "SetQuestLogItem", function(self, type, index)
+	local itemString = GetQuestLogItemLink(type, index)
+	processItemString(itemString)
+end)
+
+-- TOOLTIP: EMISSARY QUEST REWARD
+
+-- hooksecurefunc("GameTooltip_AddQuestRewardsToTooltip", function(self, questID)
+--    if GetNumQuestLogRewards(questID) > 0 then
+--        local _, _, _, _, _, id = GetQuestLogRewardInfo(1, questID)
+--        if id then
+--            processItem(id)
+--        end
+--    end
+-- end)


### PR DESCRIPTION
Allows Rarity info to be shown on GameTooltips from Quest Givers and the Quest Log. Moved the code that handles the Quest Reward to a reusable function.

Questgiver:
![image](https://user-images.githubusercontent.com/49792789/184457700-55d85a34-391e-467f-9a32-e86e1358f1f7.png)

Quest Log:
![image](https://user-images.githubusercontent.com/49792789/184457712-18cd712e-295b-44f7-b4c5-4e754a6f3a4f.png)

At the bottom I left commented out code for Emissaries. Currently the text is injected above the Quest Item so I leave it to you to finish that if you wish to use it:
![image](https://user-images.githubusercontent.com/49792789/184457793-2fc8fe76-5dfc-48fe-b143-5b33d2b604be.png)
