### PR TITLE
Fix the tagged versions check in the release workflow

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -18,8 +18,8 @@ jobs:
         uses: actions/checkout@v1
         with:
           fetch-depth: 100
-        if: startsWith(github.ref, 'refs/tags/r')
       - name: Publish new release
+        if: startsWith(github.ref, 'refs/tags/r')
         uses: BigWigsMods/packager@master
         env:
           CF_API_KEY: ${{ secrets.CURSEFORGE_API_TOKEN }}


### PR DESCRIPTION
This is clearly an oversight; instead of skipping the release for non-tagged versions the workflow will always execute the final step (skipping the checkout). Thankfully it didn't publish any releases on accident, because there's no code to publish, but it's definitely a silly mistake to make.