### PR TITLE
Fix various script errors caused by 10.0.2 API changes

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -98,9 +98,9 @@ local GetItemInfo = function(id)
 	return R:GetItemInfo(id)
 end
 local GetRealZoneText = _G.GetRealZoneText
-local GetContainerNumSlots = _G.GetContainerNumSlots
-local GetContainerItemID = _G.GetContainerItemID
-local GetContainerItemInfo = _G.GetContainerItemInfo
+local GetContainerNumSlots = _G.C_Container.GetContainerNumSlots
+local GetContainerItemID = _G.C_Container.GetContainerItemID
+local GetContainerItemInfo = _G.C_Container.GetContainerItemInfo
 local GetNumArchaeologyRaces = _G.GetNumArchaeologyRaces
 local GetArchaeologyRaceInfo = _G.GetArchaeologyRaceInfo
 local GetStatistic = _G.GetStatistic

--- a/Core/Detection.lua
+++ b/Core/Detection.lua
@@ -6,9 +6,9 @@ local table = table
 
 -- WOW API
 local C_Calendar = C_Calendar
-local GetContainerNumSlots = GetContainerNumSlots
-local GetContainerItemID = GetContainerItemID
-local GetContainerItemInfo = GetContainerItemInfo
+local GetContainerNumSlots = _G.C_Container.GetContainerNumSlots
+local GetContainerItemID = _G.C_Container.GetContainerItemID
+local GetContainerItemInfo = _G.C_Container.GetContainerItemInfo
 local GetNumSavedInstances = GetNumSavedInstances
 local GetSavedInstanceInfo = GetSavedInstanceInfo
 local GetNumRandomDungeons = GetNumRandomDungeons

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -38,9 +38,9 @@ local GetItemInfo = function(id)
 	return R:GetItemInfo(id)
 end
 local GetRealZoneText = _G.GetRealZoneText
-local GetContainerNumSlots = _G.GetContainerNumSlots
-local GetContainerItemID = _G.GetContainerItemID
-local GetContainerItemInfo = _G.GetContainerItemInfo
+local GetContainerNumSlots = _G.C_Container.GetContainerNumSlots
+local GetContainerItemID = _G.C_Container.GetContainerItemID
+local GetContainerItemInfo = _G.C_Container.GetContainerItemInfo
 local GetNumArchaeologyRaces = _G.GetNumArchaeologyRaces
 local GetArchaeologyRaceInfo = _G.GetArchaeologyRaceInfo
 local GetStatistic = _G.GetStatistic

--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -24,7 +24,9 @@ local gray = Rarity.Enum.Colors.Gray
 local white = Rarity.Enum.Colors.White
 
 -- Game Tooltip hijacking stuff
-_G.GameTooltip:HookScript("OnTooltipSetUnit", function(self)
+local function onTooltipSetUnit(tooltip, data)
+	local self = tooltip -- For backwards compatibility with the legacy code below (should be refactored eventually...)
+
 	-- If debug mode is on, find NPCID from mouseover target and append it to the tooltip
 	if R.db.profile.debugMode then
 		GameTooltip:AddLine("NPCID: " .. R:GetNPCIDFromGUID(UnitGUID("mouseover")), 255, 255, 255)
@@ -354,7 +356,9 @@ _G.GameTooltip:HookScript("OnTooltipSetUnit", function(self)
 			end
 		end
 	end
-end)
+end
+
+_G.TooltipDataProcessor.AddTooltipPostCall(_G.Enum.TooltipDataType.Unit, onTooltipSetUnit)
 
 local function processItem(id)
 	local blankAdded = false


### PR DESCRIPTION
No guarantees that something "hidden" isn't still broken, since it's infeasible to test everything. I also completely ignored the tooltip scanning changes since the old approach should still work - migrating that to the ``C_TooltipInfo`` APIs would be a separate issue.