### PR TITLE
Add a missing upvalue for GetContainerItem

### DIFF
--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -505,6 +505,7 @@ local function processItemString(itemString)
 end
 
 -- TOOLTIP: ITEMS IN INVENTORY
+local GetContainerItemID = _G.C_Container.GetContainerItemID
 
 hooksecurefunc(GameTooltip, "SetBagItem", function(self, bag, slot)
 	local id = GetContainerItemID(bag, slot)


### PR DESCRIPTION
I missed this since it was accessing the global directly instead of using an upvalue like the other calls. Why? Don't know.