### PR TITLE
Adjust early exits in the GameTooltip script handler to hopefully fix some more errors

### DIFF
--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -27,13 +27,13 @@ local white = Rarity.Enum.Colors.White
 local function onTooltipSetUnit(tooltip, data)
 	local self = tooltip -- For backwards compatibility with the legacy code below (should be refactored eventually...)
 
+	if not R.db or R.db.profile.enableTooltipAdditions == false then
+		return
+	end
+
 	-- If debug mode is on, find NPCID from mouseover target and append it to the tooltip
 	if R.db.profile.debugMode then
 		GameTooltip:AddLine("NPCID: " .. R:GetNPCIDFromGUID(UnitGUID("mouseover")), 255, 255, 255)
-	end
-
-	if not R.db or R.db.profile.enableTooltipAdditions == false then
-		return
 	end
 
 	local name, unit = self:GetUnit()

--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -31,6 +31,11 @@ local function onTooltipSetUnit(tooltip, data)
 		return
 	end
 
+	if not self.GetUnit then
+		-- Probably a tooltip created by another addon, that hasn't been updated to use GameTooltipDataMixin (risky assumption)
+		return
+	end
+
 	-- If debug mode is on, find NPCID from mouseover target and append it to the tooltip
 	if R.db.profile.debugMode then
 		GameTooltip:AddLine("NPCID: " .. R:GetNPCIDFromGUID(UnitGUID("mouseover")), 255, 255, 255)


### PR DESCRIPTION
The first part is an oversight (presumably) and should've fixed long ago.

The second part is a hack to work around errors reported by some players. I think it's due to other addons interfering by creating tooltips that don't use the new APIs, or at least aren't using them correctly (?). This is of course a bit of an assumption since I don't know what's going on and I can't reproduce the issue either. Ideally it would fix the problem by ignoring those tooltips, but realistically "anything can happen" and it will have to be adjusted again later (when more information is available).