### PR TITLE
Add another early exit condition to eliminate tooltip hooks executed for third-party tooltips

### DIFF
--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -25,6 +25,10 @@ local white = Rarity.Enum.Colors.White
 
 -- Game Tooltip hijacking stuff
 local function onTooltipSetUnit(tooltip, data)
+	if tooltip ~= _G.GameTooltip then
+		return -- Probably a tooltip created by another addon, that does use the new GameTooltipDataMixin (triggers post-hooks globally...)
+	end
+
 	local self = tooltip -- For backwards compatibility with the legacy code below (should be refactored eventually...)
 
 	if not R.db or R.db.profile.enableTooltipAdditions == false then


### PR DESCRIPTION
Whenever another addon makes use of a tooltip (frame that inherits GameTooltipDataMixin), multiple calls of the post-hook can add duplicate lines to the global GameTooltip.

I still can't test this since the issue doesn't manifest for me, but it should prevent this particular problem IFF my assumptions are correct. And if they aren't... well, then this is just useless but not actively harmful.

See discussion in #506 and on WowAce/Discord.