### PR TITLE
Update the floating combat text detection (to use CVars instead of magic globals)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1221,6 +1221,7 @@ globals = {
 	"C_WowTokenSecure.RedeemToken",
 	"C_WowTokenSecure.RedeemTokenConfirm",
 	"C_WowTokenSecure.WillKickFromWorld",
+	"CVarCallbackRegistry",
 	"CalculateAuctionDeposit",
 	"CalendarAddEvent",
 	"CalendarCanAddEvent",

--- a/Core/GUI/MainWindow.lua
+++ b/Core/GUI/MainWindow.lua
@@ -1156,7 +1156,7 @@ local function addGroup(group, requiresGroup)
 											)
 										end
 										Rarity:Print(text)
-										if tostring(SHOW_COMBAT_TEXT) ~= "0" then
+										if CVarCallbackRegistry:GetCVarValueBool("enableFloatingCombatText") then
 											if type(CombatText_AddMessage) == "nil" then
 												UIParentLoadAddOn("Blizzard_CombatText")
 											end


### PR DESCRIPTION
Blizzard has apparently replaced the magic global with a proper CVar.