### PR TITLE
Added tracking for Verdant skitterfly

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -28,7 +28,6 @@ ignore = {
 	"542", -- empty if branch (likely some commented-out code that needs to be reviewed later)
 	"512", -- loop is executed at most once (no idea why, will also have to be reviewed later)
 	"231", -- variable is never accessed (still more readable than replacing everything with underscores... remove later?)
-
 }
 globals = {
 
@@ -742,6 +741,7 @@ globals = {
 	"C_LootJournal.SetLegendaryInventoryTypeFilter",
 	"C_LossOfControl.GetEventInfo",
 	"C_LossOfControl.GetNumEvents",
+	"C_MajorFactions",
 	"C_MapBar",
 	"C_MapBar.BarIsShown",
 	"C_MapBar.GetCurrentValue",

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -47,6 +47,7 @@ local GetStatistic = _G.GetStatistic
 local GetLootSourceInfo = _G.GetLootSourceInfo
 local C_Timer = _G.C_Timer
 local IsSpellKnown = _G.IsSpellKnown
+local GetCurrentRenownLevel = C_MajorFactions.GetCurrentRenownLevel
 
 -- Addon APIs
 local DebugCache = Rarity.Utils.DebugCache
@@ -1606,6 +1607,31 @@ function R:OnEvent(event, ...)
 						v.attempts = v.attempts + 1
 					end
 					self:OutputAttempts(v)
+				end
+			end
+		end
+
+		-- Handle opening Expedition Scout's Pack (Verdant Skitterfly mount in Dragonflight)
+		if
+			Rarity.isFishing
+			and Rarity.isOpening
+			and Rarity.lastNode
+			and (Rarity.lastNode == L["Expedition Scout's Pack"])
+		then
+			local names = { "Verdant Skitterfly" }
+			Rarity:Debug("Detected Opening on " .. L["Expedition Scout's Pack"] .. " (method = SPECIAL)")
+			-- This mount has a prerequisite to drop. Renown 25 with Dragonscale Expedition
+			if GetCurrentRenownLevel(CONSTANTS.FACTION_IDS.DRAGONSCALE_EXPEDITION) >= 25 then
+				for _, name in pairs(names) do
+					local v = self.db.profile.groups.mounts[name]
+					if v and type(v) == "table" and v.enabled ~= false then
+						if v.attempts == nil then
+							v.attempts = 1
+						else
+							v.attempts = v.attempts + 1
+						end
+						self:OutputAttempts(v)
+					end
 				end
 			end
 		end

--- a/DB/Mounts/Dragonflight.lua
+++ b/DB/Mounts/Dragonflight.lua
@@ -32,6 +32,22 @@ local dragonflightMounts = {
 			{ m = CONSTANTS.UIMAPIDS.THALDRASZUS },
 		},
 	},
+	["Verdant Skitterfly"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.DRAGONFLIGHT,
+		type = CONSTANTS.ITEM_TYPES.MOUNT,
+		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+		name = L["Verdant Skitterfly"],
+		spellId = 374048,
+		itemId = 192764,
+		chance = 100, -- Blind guess
+		sourceText = L["This mount can only drop after hitting renown 25 with Dragonscale Expedition."],
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.THE_WAKING_SHORES },
+			{ m = CONSTANTS.UIMAPIDS.OHN_AHRAN_PLAINS },
+			{ m = CONSTANTS.UIMAPIDS.THE_AZURE_SPAN },
+			{ m = CONSTANTS.UIMAPIDS.THALDRASZUS },
+		},
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.mounts, dragonflightMounts)

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -250,4 +250,5 @@ R.opennodes = {
 	[L["Zovaal's Vault"]] = true,
 	[L["Mawsworn Supply Chest"]] = true,
 	[L["Sandworn Chest"]] = true,
+	[L["Expedition Scout's Pack"]] = true,
 }

--- a/DB/SharedConstants.lua
+++ b/DB/SharedConstants.lua
@@ -221,6 +221,14 @@ C.ARCHAEOLOGY_RACES = {
 	DWARF = 20,
 }
 
+C.FACTION_IDS = {
+	-- Dragonflight
+	MARUUK_CENTAUR = 2503,
+	DRAGONSCALE_EXPEDITION = 2507,
+	VALDRAKKEN_ACCORD = 2510,
+	ISKAARA_TUSKARR = 2511,
+}
+
 -- This doesn't really belong here and needs streamlining anyway, but for now this is the best place.
 -- Tooltip Filters (Note: Currently, this system is merely a stub. but more (and custom) filters may be added in the future)
 -- These are used to decide whether the tooltip should be extended to display information about an CONSTANTS.ITEM_TYPES.ITEM for the NPCs listed in its tooltipNpcs table. Useful if we want to draw attention to an CONSTANTS.ITEM_TYPES.ITEM, but not every player can obtain it

--- a/Locales.lua
+++ b/Locales.lua
@@ -1878,6 +1878,9 @@ L["Plainswalker Bearer"] = true
 L["Rockin' Rollin' Racer Customizer 19.9.3"] = true
 L["Vengeance's Reins"] = true
 L["Fractal Cypher of the Zereth Overseer"] = true
+L["Verdant Skitterfly"] = true
+L["This mount can only drop after hitting renown 25 with Dragonscale Expedition."] = true
+L["Expedition Scout's Pack"] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.


### PR DESCRIPTION
After reading through the discussion on #515 I decided to take a shot at solving it. 

PR includes the faction ID's for the 4 main dragonlflight factions, as well as handling tracking for the Verdant Skitterfly mount. Tested with a couple toons on various renown level to verify.

If merged this closes #515. :)