### PR TITLE
Add an automated check for outdated TOC interface versions

### DIFF
--- a/.github/check-interface-versions.sh
+++ b/.github/check-interface-versions.sh
@@ -1,0 +1,19 @@
+local_version=$(cat Rarity.toc | grep -oP '## Interface: \K\d+')
+options_version=$(cat Modules/Options/Rarity_Options.toc | grep -oP '## Interface: \K\d+')
+
+# Since there's no "official" way to get the latest version, just use a popular/frequently updated addon ...
+remote_version=$(curl https://raw.githubusercontent.com/BigWigsMods/BigWigs/master/BigWigs.toc --silent | grep -oP '## Interface: \K\d+')
+
+if [ "$local_version" != "$remote_version" ]; then
+    echo "Local interface version ($local_version) is not up to date with remote version ($remote_version)"
+    exit 1
+else
+    echo "Local interface version ($local_version) is up to date with remote version ($remote_version)"
+fi
+
+if [ "$local_version" != "$options_version" ]; then
+    echo "Core interface version ($local_version) is NOT identical to the options version ($options_version)"
+    exit 1
+else
+    echo "Core interface version ($local_version) is identical to the options version ($options_version)"
+fi

--- a/.github/workflows/check-toc-version.yaml
+++ b/.github/workflows/check-toc-version.yaml
@@ -1,0 +1,18 @@
+name: Table of Contents
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [master]
+
+jobs:
+  toc:
+    name: Check interface versions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Check for outdated interface versions
+        run: .github/check-interface-versions.sh

--- a/Modules/Options/Rarity_Options.toc
+++ b/Modules/Options/Rarity_Options.toc
@@ -1,6 +1,6 @@
 ## Author: Allara
-## Interface: 100002
-## X-Min-Interface: 100002
+## Interface: 100105
+## X-Min-Interface: 100105
 ## Notes: Rarity configuration. Use AddonLoader to load this on demand.
 ## Title: Rarity [|caaedc99fOptions|r]
 ## Dependencies: Rarity

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -1,6 +1,6 @@
 ## Author: Allara
-## Interface: 100002
-## X-Min-Interface: 100002
+## Interface: 100105
+## X-Min-Interface: 100105
 ## Title: Rarity
 ## Version: 1.0 (@project-version@)
 ## X-Curse-Project-ID: 30801


### PR DESCRIPTION
The interface version is perpetually out-of-date since it's so easy to forget. This causes the client to warn users, which in turn create issues or bug reports. Presumably, having an automated check in place will make it easier to remember?