### PR TITLE
Add Evoker to the list of recognized classes

### DIFF
--- a/Locales.lua
+++ b/Locales.lua
@@ -796,6 +796,7 @@ L["Announcements will only be triggered when the item is found. When this is off
 	true
 L["Death Knight"] = true
 L["Demon Hunter"] = true
+L["Evoker"] = true
 L["Druid"] = true
 L["Hunter"] = true
 L["Mage"] = true

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -71,6 +71,7 @@ local classes = {
 	["SHAMAN"] = "|c" .. RAID_CLASS_COLORS["SHAMAN"]["colorStr"] .. L["Shaman"] .. "|r",
 	["WARLOCK"] = "|c" .. RAID_CLASS_COLORS["WARLOCK"]["colorStr"] .. L["Warlock"] .. "|r",
 	["WARRIOR"] = "|c" .. RAID_CLASS_COLORS["WARRIOR"]["colorStr"] .. L["Warrior"] .. "|r",
+	["EVOKER"] = "|c" .. RAID_CLASS_COLORS["EVOKER"]["colorStr"] .. L["Evoker"] .. "|r",
 }
 
 local red = Rarity.Enum.Colors.Red


### PR DESCRIPTION
The "disable for classes" option couldn't be set for Evokers previously.