### PR TITLE
Add tracking for Reins of the Quantum Courser

### DIFF
--- a/DB/SharedConstants.lua
+++ b/DB/SharedConstants.lua
@@ -118,6 +118,7 @@ C.UIMAPIDS = {
 	THE_FORBIDDEN_REACH = 2151,
 	ZARALEK_CAVERN = 2133,
 	THE_THROUGHWAY = 2165,
+	CROSSROADS_OF_FATE = 2194, -- Dawn of the Infinite (subzone)
 }
 
 -- Types of items

--- a/DB/Toys/Dragonflight.lua
+++ b/DB/Toys/Dragonflight.lua
@@ -296,6 +296,21 @@ local dragonflightToys = {
 			{ m = CONSTANTS.UIMAPIDS.THE_WAKING_SHORES },
 		},
 	},
+	["Reins of the Quantum Courser"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.DRAGONFLIGHT,
+		type = CONSTANTS.ITEM_TYPES.ITEM, -- Not a real mount, so this'll have to do
+		isToy = false,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Reins of the Quantum Courser"],
+		itemId = 208216,
+		npcs = {
+			199000, -- Chrono-Lord Deios
+		},
+		chance = 50,
+		coords = {
+			{ m = CONSTANTS.UIMAPIDS.CROSSROADS_OF_FATE },
+		},
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.toys, dragonflightToys)

--- a/Locales.lua
+++ b/Locales.lua
@@ -2,6 +2,7 @@ local L
 L = LibStub("AceLocale-3.0"):NewLocale("Rarity", "enUS", true)
 
 -- L["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] = true
+L["Reins of the Quantum Courser"] = true
 L["Cloak of Many Faces"] = true
 L["Mage's Chewed Wand"] = true
 L["Primalist Prison"] = true


### PR DESCRIPTION
It's not a real mount, so I just added it as an item (similar to eggs).