### PR TITLE
Set Rarity as the source for created TomTom waypoints

### DIFF
--- a/Core/GUI/MainWindow.lua
+++ b/Core/GUI/MainWindow.lua
@@ -201,7 +201,7 @@ local function onClickItem(cell, item)
 							coord.m,
 							coord.x / 100.0,
 							coord.y / 100.0,
-							{ title = "Rarity" .. ": " .. item.name .. extraName }
+							{ title = item.name .. extraName, from = "Rarity" }
 						)
 						added = added + 1
 					end


### PR DESCRIPTION
Instead of prepending Rarity to the waypoint name, it seems cleaner to use the TomTom API's "from" field. Maybe that's a recent addition? Either way, it de-clutters the waypoint title a little bit and fixes the  "From: ?" part. No big deal.

Before:

![image](https://github.com/WowRarity/Rarity/assets/16489133/300eee1c-3430-4a58-b42a-2e66327df554)

After:

![image](https://github.com/WowRarity/Rarity/assets/16489133/7e953aec-3497-434f-bfad-74c72a23d7a2)

(Ignoring the extra name, since I forgot to add this in the first screenshot)