### PR TITLE
Add Everlasting Horn of Lavaswimming (toy) to the database

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -428,9 +428,9 @@ function R:OnCombat()
 	end
 end
 
--- Handle quest turnins: Only used to detect world quests used for outdoor world bosses. It's not ideal, but probably more reliable than the loot lockout quest (which may or may not already be completed when the UNIT_DIED event is fired)
-local worldBossQuests = {
+local worldEventQuests = {
 	[52196] = "Slightly Damp Pile of Fur", -- Dunegorger Kraulok
+	[70867] = "Everlasting Horn of Lavaswimming", -- Scalebane Keep (scenario completion)
 }
 
 function R:OnQuestTurnedIn(event, questID, experience, money)
@@ -438,7 +438,7 @@ function R:OnQuestTurnedIn(event, questID, experience, money)
 		"OnQuestTurnedIn triggered with ID = " .. questID .. ", experience = " .. experience .. ", money = " .. money
 	)
 
-	local relevantItem = worldBossQuests[questID]
+	local relevantItem = worldEventQuests[questID]
 	if not relevantItem then
 		return
 	end

--- a/DB/Toys/Dragonflight.lua
+++ b/DB/Toys/Dragonflight.lua
@@ -380,6 +380,17 @@ local dragonflightToys = {
 			{ m = CONSTANTS.UIMAPIDS.THE_PRIMALIST_FUTURE },
 		},
 	},
+	["Everlasting Horn of Lavaswimming"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.DRAGONFLIGHT,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+		name = L["Everlasting Horn of Lavaswimming"],
+		itemId = 200116,
+		chance = 40, --guess
+		sourceText = L["This toy is obtained at the end of the Siege on Dragonbane Keep event."],
+		coords = { { m = CONSTANTS.UIMAPIDS.THE_WAKING_SHORES, x = 24.2, y = 70.1 } },
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.toys, dragonflightToys)

--- a/Locales.lua
+++ b/Locales.lua
@@ -1988,6 +1988,8 @@ L["Gooey Snailemental"] = true
 L["Dropped from the final bosses of Froststone Vault Primal Storm."] = true
 L["Combine 50 Leftover Elemental Slime to create the Gooey Snailemental."] = true
 L["Froststone Vault Primal Storm"] = true
+L["Everlasting Horn of Lavaswimming"] = true
+L["This toy is obtained at the end of the Siege on Dragonbane Keep event."] = true
 
 --[[
 					The rest of this file is auto-generated using the WoWAce localization application.


### PR DESCRIPTION
adding Everlasting Horn of Lavaswimming toy. Too get a more accurate tracking on this toy you would have to track the event completion but for now its tracked by killing the mob "Inferna the Bound" at the end of the event "Siege on Dragonbane Keep".