### PR TITLE
Update the NPC list for Gahz'rooki's Summoning Stone

### DIFF
--- a/DB/Pets/MistsOfPandaria.lua
+++ b/DB/Pets/MistsOfPandaria.lua
@@ -449,7 +449,10 @@ local mopPets = {
 		name = L["Gahz'rooki's Summoning Stone"],
 		spellId = 141789,
 		itemId = 97821,
-		npcs = { 71012, 70997, 71000, 70999, 71001 },
+		npcs = {
+			71012, -- Kor'kron Butcher
+			73590, -- Kor'kron Outrider
+		},
 		chance = 1000,
 		creatureId = 71159,
 		coords = { { m = 10, x = 43.7, y = 47.9 } },


### PR DESCRIPTION
It seems that the level squish changed the drop table of several relevant NPCs. Any that are now level 30 seem to no longer drop MOP items, and wowhead comments as well as a user report (15k attempts, not a single drop) suggests that the pet cannot be obtained from them at this time.

It's certainly possible that the pet does drop from level 30 enemies after all, but knowing Blizzard I'd rather err on the side of caution and avoid people wasting their time killing these NPCs.

While looking into the report I also noticed an NPC was missing, so I've added that one while I'm at it.

---

See also: https://www.wowace.com/projects/rarity/issues/521