### PR TITLE
Fix various waypoint labels for Dragonflight collectibles

### DIFF
--- a/DB/Pets/Dragonflight.lua
+++ b/DB/Pets/Dragonflight.lua
@@ -50,7 +50,7 @@ local dragonflightPets = {
 		creatureId = 189118,
 		groupSize = 5,
 		equalOdds = true,
-		coords = { { m = CONSTANTS.UIMAPIDS.THE_FORBIDDEN_REACH, x = 43.6, y = 61.0, L["Bonesifter Marwak"] } },
+		coords = { { m = CONSTANTS.UIMAPIDS.THE_FORBIDDEN_REACH, x = 43.6, y = 61.0, n = L["Bonesifter Marwak"] } },
 	},
 	["Gilded Mechafrog"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.DRAGONFLIGHT,
@@ -64,7 +64,7 @@ local dragonflightPets = {
 		sourceText = L["Inside Zskera Vaults, collect Neltharion Gift Tokens for Prototype Tinker-Tron in order to receive Tattered Gift Package, which can drop the Gilded Mechafrog pet."],
 		chance = 25,
 		coords = {
-			{ m = CONSTANTS.UIMAPIDS.THE_FORBIDDEN_REACH, x = 29.2, y = 53.0, L["Entrance to Zskera Vault"] },
+			{ m = CONSTANTS.UIMAPIDS.THE_FORBIDDEN_REACH, x = 29.2, y = 53.0, n = L["Entrance to Zskera Vault"] },
 		},
 	},
 	["Dust Spirit"] = {
@@ -78,7 +78,7 @@ local dragonflightPets = {
 		creatureId = 198271,
 		sourceText = L["Collect Encaged Earthen Soul and wait 15min until it turns into Docile Earthen Soul, then open it for a chance at the pet."],
 		chance = 50,
-		coords = { { m = CONSTANTS.UIMAPIDS.THE_WAKING_SHORES, x = 52.8, y = 30.6, L["Earthshatter Elemental"] } },
+		coords = { { m = CONSTANTS.UIMAPIDS.THE_WAKING_SHORES, x = 52.8, y = 30.6, n = L["Earthshatter Elemental"] } },
 	},
 	["Blaze Spirit"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.DRAGONFLIGHT,
@@ -91,7 +91,7 @@ local dragonflightPets = {
 		creatureId = 198272,
 		sourceText = L["Collect Encaged Fiery Soul and wait 15min until it turns into Docile Fiery Soul, then open it for a chance at the pet."],
 		chance = 50,
-		coords = { { m = CONSTANTS.UIMAPIDS.THE_AZURE_SPAN, x = 79.4, y = 38.2, L["Fire Elemental"] } },
+		coords = { { m = CONSTANTS.UIMAPIDS.THE_AZURE_SPAN, x = 79.4, y = 38.2, n = L["Fire Elemental"] } },
 	},
 	["Gale Spirit"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.DRAGONFLIGHT,
@@ -104,7 +104,7 @@ local dragonflightPets = {
 		creatureId = 198273,
 		sourceText = L["Collect Encaged Airy Soul and wait 15min until it turns into Docile Airy Soul, then open it for a chance at the pet."],
 		chance = 50,
-		coords = { { m = CONSTANTS.UIMAPIDS.OHN_AHRAN_PLAINS, x = 23.2, y = 37.6, L["Stormbound Colossus"] } },
+		coords = { { m = CONSTANTS.UIMAPIDS.OHN_AHRAN_PLAINS, x = 23.2, y = 37.6, n = L["Stormbound Colossus"] } },
 	},
 	["Tide Spirit"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.DRAGONFLIGHT,
@@ -117,7 +117,7 @@ local dragonflightPets = {
 		creatureId = 198269,
 		sourceText = L["Collect Encaged Frosty Soul and wait 15min until it turns into Docile Frosty Soul, then open it for a chance at the pet."],
 		chance = 50,
-		coords = { { m = CONSTANTS.UIMAPIDS.OHN_AHRAN_PLAINS, x = 55.2, y = 76.7, L["Force of the Springs"] } },
+		coords = { { m = CONSTANTS.UIMAPIDS.OHN_AHRAN_PLAINS, x = 55.2, y = 76.7, n = L["Force of the Springs"] } },
 	},
 	["Scruffles"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.DRAGONFLIGHT,

--- a/DB/Toys/Dragonflight.lua
+++ b/DB/Toys/Dragonflight.lua
@@ -15,10 +15,10 @@ local dragonflightToys = {
 		npcs = { 193210, 193176, 193126, 193241 },
 		chance = 6,
 		coords = {
-			{ m = CONSTANTS.UIMAPIDS.THALDRASZUS, x = 58.4, y = 85.6, L["Phleep"] },
-			{ m = CONSTANTS.UIMAPIDS.THALDRASZUS, x = 37.6, y = 78.0, L["Sandana the Tempest"] },
-			{ m = CONSTANTS.UIMAPIDS.THALDRASZUS, x = 60.6, y = 82.6, L["Innumerable Ruination"] },
-			{ m = CONSTANTS.UIMAPIDS.THALDRASZUS, x = 62.2, y = 81.6, L["Lord Epochbrgl"] },
+			{ m = CONSTANTS.UIMAPIDS.THALDRASZUS, x = 58.4, y = 85.6, n = L["Phleep"] },
+			{ m = CONSTANTS.UIMAPIDS.THALDRASZUS, x = 37.6, y = 78.0, n = L["Sandana the Tempest"] },
+			{ m = CONSTANTS.UIMAPIDS.THALDRASZUS, x = 60.6, y = 82.6, n = L["Innumerable Ruination"] },
+			{ m = CONSTANTS.UIMAPIDS.THALDRASZUS, x = 62.2, y = 81.6, n = L["Lord Epochbrgl"] },
 		},
 	},
 	["Personal Shell"] = {
@@ -31,7 +31,7 @@ local dragonflightToys = {
 		npcs = { 193133 },
 		chance = 2,
 		coords = {
-			{ m = CONSTANTS.UIMAPIDS.OHN_AHRAN_PLAINS, x = 63.2, y = 48.6, L["Sunscale Behemoth"] },
+			{ m = CONSTANTS.UIMAPIDS.OHN_AHRAN_PLAINS, x = 63.2, y = 48.6, n = L["Sunscale Behemoth"] },
 		},
 	},
 	["Infected Ichor"] = {
@@ -44,9 +44,9 @@ local dragonflightToys = {
 		npcs = { 193128, 197356, 193178 },
 		chance = 12,
 		coords = {
-			{ m = CONSTANTS.UIMAPIDS.OHN_AHRAN_PLAINS, x = 90.4, y = 40.0, L["Blightpaw the Depraved"] },
-			{ m = CONSTANTS.UIMAPIDS.THE_AZURE_SPAN, x = 16.2, y = 33.6, L["High Shaman Rotknuckle"] },
-			{ m = CONSTANTS.UIMAPIDS.THE_AZURE_SPAN, x = 13.4, y = 22.6, L["Blightfur"] },
+			{ m = CONSTANTS.UIMAPIDS.OHN_AHRAN_PLAINS, x = 90.4, y = 40.0, n = L["Blightpaw the Depraved"] },
+			{ m = CONSTANTS.UIMAPIDS.THE_AZURE_SPAN, x = 16.2, y = 33.6, n = L["High Shaman Rotknuckle"] },
+			{ m = CONSTANTS.UIMAPIDS.THE_AZURE_SPAN, x = 13.4, y = 22.6, n = L["Blightfur"] },
 		},
 	},
 	["Aquatic Shades"] = {
@@ -59,7 +59,7 @@ local dragonflightToys = {
 		items = { 202102 },
 		chance = 2,
 		coords = {
-			{ m = CONSTANTS.UIMAPIDS.OHN_AHRAN_PLAINS, x = 82.2, y = 73.2, L["Immaculate Sac of Swog Treasures"] },
+			{ m = CONSTANTS.UIMAPIDS.OHN_AHRAN_PLAINS, x = 82.2, y = 73.2, n = L["Immaculate Sac of Swog Treasures"] },
 		},
 	},
 	["The Super Shellkhan Gang"] = {
@@ -72,7 +72,7 @@ local dragonflightToys = {
 		npcs = { 191305 },
 		chance = 3,
 		coords = {
-			{ m = CONSTANTS.UIMAPIDS.THALDRASZUS, x = 38.4, y = 68.6, L["The Great Shellkhan"] },
+			{ m = CONSTANTS.UIMAPIDS.THALDRASZUS, x = 38.4, y = 68.6, n = L["The Great Shellkhan"] },
 		},
 	},
 	["Notfar's Favorite Food"] = {
@@ -85,7 +85,7 @@ local dragonflightToys = {
 		npcs = { 198703 },
 		chance = 6,
 		coords = {
-			{ m = CONSTANTS.UIMAPIDS.THE_AZURE_SPAN, x = 20.6, y = 49.6, L["Notfar the Unbearable"] },
+			{ m = CONSTANTS.UIMAPIDS.THE_AZURE_SPAN, x = 20.6, y = 49.6, n = L["Notfar the Unbearable"] },
 		},
 	},
 	["Talisman of Sargha"] = {


### PR DESCRIPTION
Clearly an oversight, which should've been caught by automated tests...