### PR TITLE
Fix the detection logic for opening faction-specific containers

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -963,15 +963,21 @@ function R:ProcessContainerItems()
 										and vv.items ~= nil
 										and type(vv.items) == "table"
 									then
-										for kkk, vvv in pairs(vv.items) do
-											if vvv == k then
-												local i = vv
-												if i.attempts == nil then
-													i.attempts = 1
-												else
-													i.attempts = i.attempts + 1
+										local isHordePlayer = R.Caching:IsHorde()
+										local canPlayerObtainFactionSpecificItem = not (
+												vv.requiresHorde and not isHordePlayer
+											) or (vv.requiresAlliance and isHordePlayer)
+										if canPlayerObtainFactionSpecificItem then
+											for kkk, vvv in pairs(vv.items) do
+												if vvv == k then
+													local i = vv
+													if i.attempts == nil then
+														i.attempts = 1
+													else
+														i.attempts = i.attempts + 1
+													end
+													self:OutputAttempts(i)
 												end
-												self:OutputAttempts(i)
 											end
 										end
 									end


### PR DESCRIPTION
If a faction-specific item is obtained from a container, such as the mounts from Time Rift boxes, then the detection adds an attempt for it even though the player's faction doesn't match the requirement. This fix is "hacky" because I don't dare to touch the nested loops right now; ideally it'd be tested via CI and probably restructured a bit, but that will just have to wait (unfortunately).