### PR TITLE
Fix the tooltip for faction specific container items

### DIFF
--- a/Core/Database.lua
+++ b/Core/Database.lua
@@ -37,5 +37,24 @@ function Database:PurgeObsoleteEntries()
 	end
 end
 
+function Database.IsItemAvailableToFactionGroup(item, englishFactionGroupName)
+	local isHorde = (englishFactionGroupName == "Horde")
+	local isAlliance = (englishFactionGroupName == "Alliance")
+
+	if not item.requiresAlliance and not item.requiresHorde then
+		return true
+	end
+
+	if item.requiresAlliance and isAlliance then
+		return true
+	end
+
+	if item.requiresHorde and isHorde then
+		return true
+	end
+
+	return false
+end
+
 Rarity.Database = Database
 return Database

--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -12,6 +12,7 @@ local lbz = LibStub("LibBabble-Zone-3.0"):GetUnstrictLookupTable()
 --- WoW API
 local GetBestMapForUnit = _G.C_Map.GetBestMapForUnit
 local IsQuestFlaggedCompleted = _G.C_QuestLog.IsQuestFlaggedCompleted
+local UnitFactionGroup = _G.UnitFactionGroup
 --- Addon API
 local CONSTANTS = addonTable.constants
 local colorize = Rarity.Utils.String.Colorize
@@ -378,7 +379,9 @@ local function processItem(id)
 		-- This item is used to obtain another item
 		if Rarity.items_to_items[id] then
 			for k, v in pairs(Rarity.items_to_items[id]) do
-				if v.itemId then
+				local playerFaction = UnitFactionGroup("player")
+				local isItemAvailableToPlayer = Rarity.Database.IsItemAvailableToFactionGroup(v, playerFaction)
+				if v.itemId and isItemAvailableToPlayer then
 					local itemName, itemLink, itemRarity, itemLevel, itemMinLevel, itemType, itemSubType, itemStackCount, itemEquipLoc, itemTexture, itemSellPrice =
 						GetItemInfo(v.itemId)
 					if itemLink or itemName or v.name then

--- a/Tests/test-database.spec.lua
+++ b/Tests/test-database.spec.lua
@@ -1,0 +1,48 @@
+local Database = loadfile("Core/Database.lua")("Rarity", {})
+
+local ITEM_THAT_REQUIRES_ALLIANCE = {
+	requiresAlliance = true,
+}
+local ITEM_THAT_REQUIRES_HORDE = {
+	requiresHorde = true,
+}
+local ITEM_THAT_REQUIRES_BOTH = {
+	requiresAlliance = true,
+	requiresHorde = true,
+}
+
+describe("Database", function()
+	describe("IsItemAvailableToFactionGroup", function()
+		it("should return true for Alliance players if the item doesn't require any given faction", function()
+			assertTrue(Database.IsItemAvailableToFactionGroup({}, "Alliance"))
+		end)
+
+		it("should return true for Horde players if the item doesn't require any given faction", function()
+			assertTrue(Database.IsItemAvailableToFactionGroup({}, "Alliance"))
+		end)
+
+		it("should return true for Alliance players if the item requires Alliance", function()
+			assertTrue(Database.IsItemAvailableToFactionGroup(ITEM_THAT_REQUIRES_ALLIANCE, "Alliance"))
+		end)
+
+		it("should return false for Horde players if the item requires Alliance", function()
+			assertFalse(Database.IsItemAvailableToFactionGroup(ITEM_THAT_REQUIRES_ALLIANCE, "Horde"))
+		end)
+
+		it("should return false for Alliance players if the item requires Horde", function()
+			assertFalse(Database.IsItemAvailableToFactionGroup(ITEM_THAT_REQUIRES_HORDE, "Alliance"))
+		end)
+
+		it("should return true for Horde players if the item requires Horde", function()
+			assertTrue(Database.IsItemAvailableToFactionGroup(ITEM_THAT_REQUIRES_HORDE, "Horde"))
+		end)
+
+		it("should return true for Alliance players if the item requires both factions", function()
+			assertTrue(Database.IsItemAvailableToFactionGroup(ITEM_THAT_REQUIRES_BOTH, "Alliance"))
+		end)
+
+		it("should return true for Horde players if the item requires both factions", function()
+			assertTrue(Database.IsItemAvailableToFactionGroup(ITEM_THAT_REQUIRES_BOTH, "Horde"))
+		end)
+	end)
+end)

--- a/Tests/unit-test.lua
+++ b/Tests/unit-test.lua
@@ -3,6 +3,7 @@ require("Tests.WOWAPI")
 require("Tests.RarityCoreSetup")
 
 local specFiles = {
+	"Tests/test-database.spec.lua",
 	"Tests/test-serialization.spec.lua",
 }
 


### PR DESCRIPTION
As a follow-up to the attempts detection fix, the UI should reflect that the item can't be obtained by players of the opposite faction.

Example: Time Rift boxes display the Horde mount (wolf) on Alliance, but opening the box correctly doesn't add the attempts. That'll be quite confusing and it's best to just hide the item for Alliance players.

---

Follow-up to #612 