### PR TITLE
Replace the LOOT_READY session lockout with a bucketed event handler

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -57,7 +57,7 @@ function EventHandlers:Register()
 
 	self:UnregisterAllEvents()
 	self:RegisterBucketEvent("BAG_UPDATE", 0.5, "OnBagUpdate")
-	self:RegisterEvent("LOOT_READY", "OnLootReady")
+	self:RegisterBucketEvent({ "LOOT_READY", "LOOT_OPENED", "LOOT_READY" }, 0.5, "OnLootReady")
 	self:RegisterEvent("CURRENCY_DISPLAY_UPDATE", "OnCurrencyUpdate")
 	self:RegisterEvent("RESEARCH_ARTIFACT_COMPLETE", "OnResearchArtifactComplete")
 	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED", "OnCombat") -- Used to detect boss kills that we didn't solo

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1227,14 +1227,6 @@ function R:OnLootReady(event, ...)
 			return
 		end
 
-		-- In 8.0.1, two LOOT_READY events fire when the loot window opens. We'll just ignore subsequent events for a short time to prevent double counting
-		if Rarity.Session:IsLocked() then -- One attempt is already being counted and we don't want another one for this loot event -> Ignore this call
-			Rarity:Debug("Session is locked; ignoring this LOOT_READY event")
-			return
-		else
-			Rarity.Session:Lock(1)
-		end
-
 		local zone = GetRealZoneText()
 		local subzone = GetSubZoneText()
 		local zone_t = LibStub("LibBabble-Zone-3.0"):GetReverseLookupTable()[zone]

--- a/Core/Session.lua
+++ b/Core/Session.lua
@@ -12,13 +12,11 @@ local GetDate = Rarity.Utils.Time.GetDate
 -- WOW APIs
 local GetItemInfo = GetItemInfo
 local GetTime = GetTime
-local C_Timer = C_Timer
 
 -- Locals
 local inSession = false
 local sessionStarted = 0
 local sessionLast = 0
-local isSessionLocked = false
 local sessionTimer
 
 -- Constants
@@ -145,26 +143,6 @@ function Session:Update()
 	else
 		Rarity.Session:Start()
 	end
-end
-
-function Session:IsLocked()
-	return isSessionLocked
-end
-
-function Session.Unlock()
-	Rarity:Debug("Unlocking session to continue scanning for new LOOT_READY events")
-	isSessionLocked = false
-end
-
-function Session:Lock(delay)
-	delay = delay or 1 -- 1 second seems to be a suitable default value (as both events fire within 0.5-0.8s of each other)
-
-	-- Lock the current session (and set the timer to unlock it again)
-	Rarity:Debug(
-		"Locking session for " .. tostring(delay) .. " second(s) to prevent duplicate attempts from being counted"
-	)
-	isSessionLocked = true
-	C_Timer.After(delay, self.Unlock) -- Unlock via timer
 end
 
 Rarity.Session = Session


### PR DESCRIPTION
Much cleaner, simpler, and more reliable. The timeout is still adjustable so nothing should have been lost.