### PR TITLE
Fix no loot tracking after using mailbox

### DIFF
--- a/luacheckrc.lua
+++ b/luacheckrc.lua
@@ -147,6 +147,9 @@ globals = {
 	"GAME_LOCALE",
 	"SPLASH_LEGION_NEW_7_1_RIGHT_TITLE",
 
+	-- ENUMS
+	"Enum",
+
 	-- API functions
 	"AbandonQuest",
 	"AbandonSkill",


### PR DESCRIPTION
10.x added new events to handle open/close frames for many game UI frames—things like the guild/bank, the auction house, and the mailbox. The old events still exist; some actions trigger both old and new events, some trigger only the old event, and some only trigger the new event. (Most likely, more events will cut over from old to new in future game releases.)

This adds EventRemapping to basically convert new style events to old style events, allowing existing event handler code to work with either type of event.

Most notably here, the MAIL_CLOSED event no longer fires when leaving the mailbox; this left Rarity thinking the player is at the mailbox, so it would ignore loot events.  After EventRemapping, Rarity sees "MAIL_CLOSED" again, hopefully fixing a longstanding issue where loots would be ignored, seemingly inconsistently.