### PR TITLE
Fix OnLootReady handling with 3rd party loot addons

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -58,7 +58,7 @@ function EventHandlers:Register()
 
 	self:UnregisterAllEvents()
 	self:RegisterBucketEvent("BAG_UPDATE", 0.5, "OnBagUpdate")
-	self:RegisterBucketEvent({ "LOOT_READY", "LOOT_OPENED", "LOOT_READY" }, 0.5, "OnLootReady")
+	self:RegisterBucketEvent("LOOT_READY", 0.5, "OnLootReady")
 	self:RegisterEvent("CURRENCY_DISPLAY_UPDATE", "OnCurrencyUpdate")
 	self:RegisterEvent("RESEARCH_ARTIFACT_COMPLETE", "OnResearchArtifactComplete")
 	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED", "OnCombat") -- Used to detect boss kills that we didn't solo


### PR DESCRIPTION
There have been reports of the latest loot handling change causing attempts to not be registered. After some investigation, it turns out that certain "fast loot" addons exist that basically spam-loot via LootItem API on LOOT_READY. Examples of these are AutoLootPlusPlus and ElvUI_WindTools/FastLoot

Both of them cause the LOOT_OPENED event to not be triggered, which means Rarity won't trigger OnLootReady either - or at least not reliably. Since we used only LOOT_READY before, there's probably no reason to rely on LOOT_OPENED as long as the detection is working fine (and spam-opening containers doesn't fail).

If this causes problems for regular users it should be rolled back.