### PR TITLE
Update DB entry for Everlasting Horn of Lavaswimming

### DIFF
--- a/DB/Toys/Dragonflight.lua
+++ b/DB/Toys/Dragonflight.lua
@@ -394,8 +394,9 @@ local dragonflightToys = {
 		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
 		name = L["Everlasting Horn of Lavaswimming"],
 		itemId = 200116,
-		chance = 40, --guess
-		sourceText = L["This toy is obtained at the end of the Siege on Dragonbane Keep event."],
+		chance = 1000,
+		sourceText = L["This toy is obtained at the end of the Siege on Dragonbane Keep event. The drop rate appears to be much reduced on repeated attempts."],
+		questId = { 70866, 74295 },
 		coords = { { m = CONSTANTS.UIMAPIDS.THE_WAKING_SHORES, x = 24.2, y = 70.1 } },
 	},
 	["Holoviewer: The Lady of Dreams"] = {

--- a/Locales.lua
+++ b/Locales.lua
@@ -1994,7 +1994,8 @@ L["Dropped from the final bosses of Froststone Vault Primal Storm."] = true
 L["Combine 50 Leftover Elemental Slime to create the Gooey Snailemental."] = true
 L["Froststone Vault Primal Storm"] = true
 L["Everlasting Horn of Lavaswimming"] = true
-L["This toy is obtained at the end of the Siege on Dragonbane Keep event."] = true
+L["This toy is obtained at the end of the Siege on Dragonbane Keep event. The drop rate appears to be much reduced on repeated attempts."] =
+	true
 L["Opera Chest"] = true
 L["Holoviewer: The Lady of Dreams"] = true
 L["Holoviewer: The Timeless One"] = true


### PR DESCRIPTION
It seems that the drop rate is questionably low and no information about this item was made available by Blizzard. Since I don't want to have people try and farm this repeatedly thinking they'll get it in 40 attempts, let's make it very clear that that the drop rate might be abysmal. Hopefully, this will prompt some research so people can make a more informed decision, or postpone farming this until more data has been gathered by the community.

In the same vein, using the weekly quest for defeat detection makes the most sense, to discourage players from repeatedly farming it (without doing more research first, that is). And to be even clearer, I'll also adjust the sourceText, although it may have to be updated again later should we get better info on this thing.