### PR TITLE
Re-introduce the session locking mechanism

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -58,7 +58,7 @@ function EventHandlers:Register()
 
 	self:UnregisterAllEvents()
 	self:RegisterBucketEvent("BAG_UPDATE", 0.5, "OnBagUpdate")
-	self:RegisterBucketEvent("LOOT_READY", 0.5, "OnLootReady")
+	self:RegisterEvent("LOOT_READY", "OnLootReady")
 	self:RegisterEvent("CURRENCY_DISPLAY_UPDATE", "OnCurrencyUpdate")
 	self:RegisterEvent("RESEARCH_ARTIFACT_COMPLETE", "OnResearchArtifactComplete")
 	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED", "OnCombat") -- Used to detect boss kills that we didn't solo
@@ -1239,6 +1239,14 @@ end
 function R:OnLootReady(event, ...)
 	do
 		self:Debug("LOOT_READY with target: " .. (UnitGUID("target") or "NO TARGET"))
+
+		-- Two LOOT_READY events may trigger when the loot window opens, in which case this prevents double counting
+		if self.Session:IsLocked() then
+			self:Debug("Session is locked; ignoring this LOOT_READY event")
+			return
+		end
+
+		self.Session:Lock()
 
 		if Rarity.isBankOpen then
 			Rarity:Debug("Ignoring this LOOT_READY event (bank is open)")

--- a/Core/Session.lua
+++ b/Core/Session.lua
@@ -2,7 +2,10 @@ local _, addonTable = ...
 
 --- Session.lua
 -- TODO: LuaDoc
-local Session = {}
+local Session = {
+	lockDurationInSeconds = 1, -- Should be configurable for easier debugging
+	isLocked = false,
+}
 
 -- Globals
 local R = Rarity
@@ -12,6 +15,7 @@ local GetDate = Rarity.Utils.Time.GetDate
 -- WOW APIs
 local GetItemInfo = GetItemInfo
 local GetTime = GetTime
+local C_Timer = C_Timer
 
 -- Locals
 local inSession = false
@@ -143,6 +147,27 @@ function Session:Update()
 	else
 		Rarity.Session:Start()
 	end
+end
+
+function Session:IsLocked()
+	return self.isLocked
+end
+
+function Session.Unlock()
+	Rarity:Debug("Unlocking session to continue scanning for new LOOT_READY events")
+	Session.isLocked = false
+end
+
+function Session:Lock(lockDurationInSeconds)
+	lockDurationInSeconds = lockDurationInSeconds or self.lockDurationInSeconds
+
+	Rarity:Debug(
+		"Locking session for "
+			.. tostring(lockDurationInSeconds)
+			.. " second(s) to prevent duplicate attempts from being counted"
+	)
+	self.isLocked = true
+	C_Timer.After(lockDurationInSeconds, self.Unlock)
 end
 
 Rarity.Session = Session


### PR DESCRIPTION
As is evident from the various looting-related bug reports, "fast loot" addons still break Rarity's NPC detection method - even with the latest changes. I suspect this is due to how AceEvent handles the aggregated LOOT_READY triggers: By the time we're notified the fast loot addon has already taken all the loot, so Rarity can't see anything (and thus won't add any attempts).

This should be largely identical to the previous implementation, the only change being that the delay is now configurable (through code only, for now). If spam-opening containers becomes a significant concern, the delay could be exposed to the config UI to allow users to adjust it so that attempts are no longer failing to be detected.

Obviously, this is sub-optimal as ideally we'd be able to handle both scenarios gracefully. But one being seemingly more prevalent than the other, I'd rather not break "fast loot" addons and deal with the relatively fewer bug reports concerning container items not being counted. Perhaps a better solution exists that solves both problems at once, but I really don't have the time to do more than what's absolutely necessary here.

---

Follow-up to #629 and #620