### PR TITLE
Replace hardcoded map IDs for Darkmoon Island

### DIFF
--- a/DB/Pets/HolidayEvents.lua
+++ b/DB/Pets/HolidayEvents.lua
@@ -163,7 +163,7 @@ local holidayEventPets = {
 		chance = 17,
 		creatureId = 72160,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.DARKMOON_FAIRE,
-		coords = { { m = 407, x = 39.8, y = 44.4, n = L["Moonfang"] } },
+		coords = { { m = CONSTANTS.UIMAPIDS.DARKMOON_ISLAND, x = 39.8, y = 44.4, n = L["Moonfang"] } },
 	},
 	["Red Helper Box"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,

--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -214,7 +214,7 @@ local holidayEventToys = {
 		npcs = { 71992 },
 		chance = 5,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.DARKMOON_FAIRE,
-		coords = { { m = 407, x = 39.8, y = 44.4 } },
+		coords = { { m = CONSTANTS.UIMAPIDS.DARKMOON_ISLAND, x = 39.8, y = 44.4 } },
 	},
 	["Moonfang's Paw"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
@@ -226,7 +226,7 @@ local holidayEventToys = {
 		npcs = { 71992 },
 		chance = 5,
 		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.DARKMOON_FAIRE,
-		coords = { { m = 407, x = 39.8, y = 44.4 } },
+		coords = { { m = CONSTANTS.UIMAPIDS.DARKMOON_ISLAND, x = 39.8, y = 44.4 } },
 	},
 	["Pineapple Lounge Cushion"] = {
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,


### PR DESCRIPTION
Now that there's a shared constant, might as well use it.