### PR TITLE
Update the changelog for r723

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,15 +1,7 @@
-**r722:**
+**r723:**
 
 Additions:
-> Added tracking for collectibles obtainable in the Zskera Vaults (Forbidden Reach)
-
-Changes:
-> The estimated luckiness percentage is now being displayed alongside the attempts count for all items
+> Added tracking for Darkmoon Rabbit
 
 Fixes:
-> Fixed an issue that would incorrectly add duplicate attempts for bosses with both kill statistics and NPC loot
-<br>Rolled back a recent change that caused NPC loot to not be registered when using Rarity with fast-loot addons
-
-Contributors (in alphabetical order):
-> cyriun
-<br>Rubio9
+> Fixed an issue that prevented items requiring world events (e.g., DMF) to be active from being displayed

--- a/Changes.lua
+++ b/Changes.lua
@@ -1,4 +1,12 @@
 local changes = {
+	["r723"] = {
+		additions = {
+			"Added tracking for Darkmoon Rabbit",
+		},
+		fixes = {
+			"Fixed an issue that prevented items requiring world events (e.g., DMF) to be active from being displayed",
+		},
+	},
 	["r722"] = {
 		additions = {
 			"Added tracking for collectibles obtainable in the Zskera Vaults (Forbidden Reach)",


### PR DESCRIPTION
Bit late for the Darkmoon Faire fix, but the TOC version has changed and the addon is now being displayed as "outdated" again.