### PR TITLE
Create a UI window (scrolling message frame) to more easily manage cached debug messages

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -55,6 +55,13 @@ globals = {
 	"READY_CHECK_WAITING_TEXTURE",
 
 	-- FrameXML (Blizzard interface)
+	"BackdropTemplateMixin",
+	"ChatFontNormal",
+	"FauxScrollFrame_GetOffset",
+	"FauxScrollFrame_OnVerticalScroll",
+	"FauxScrollFrame_Update",
+	"SCROLLING_MESSAGE_FRAME_INSERT_MODE_TOP",
+
 	"AchievementFrame",
 	"AchievementFrame_LoadUI",
 	"AchievementShield_SetPoints",

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -718,8 +718,7 @@ function R:OnChatCommand(input)
 			self:Print(L["Debug mode ON"])
 		end
 	elseif strlower(input) == "dump" then
-		local numMessages = 50 -- Hardcoded is meh, but it should suffice for the time being
-		DebugCache:PrintMessages(numMessages)
+		self.ScrollingDebugMessageFrame:Toggle()
 	elseif strlower(input) == "validate" then -- Verify the ItemDB
 		self.Validation:ValidateItemDB()
 	elseif strlower(input) == "mapinfo" then

--- a/Core/GUI/ScrollingDebugMessageFrame.lua
+++ b/Core/GUI/ScrollingDebugMessageFrame.lua
@@ -1,0 +1,104 @@
+local ScrollingDebugMessageFrame = {
+	numMessagesToDisplay = 30,
+	backdropSettings = {
+		bgFile = "Interface/BUTTONS/WHITE8X8",
+		edgeFile = "Interface/GLUES/Common/Glue-Tooltip-Border",
+		tile = true,
+		edgeSize = 8,
+		tileSize = 8,
+		insets = {
+			left = 5,
+			right = 5,
+			top = 5,
+			bottom = 5,
+		},
+	},
+}
+
+local CopyPastePopup = Rarity.CopyPastePopup
+local DebugCache = Rarity.Utils.DebugCache
+
+function ScrollingDebugMessageFrame:OnLoad()
+	local numSavedLines = DebugCache.cacheSize
+
+	local frame =
+		CreateFrame("Frame", "RarityScrollingDebugMessageFrame", UIParent, BackdropTemplateMixin and "BackdropTemplate")
+	frame:SetSize(1024, 640)
+	frame:SetPoint("CENTER")
+	frame:SetAlpha(0.5)
+	frame:SetFrameStrata("BACKGROUND")
+	frame:SetBackdrop(self.backdropSettings)
+	frame:SetBackdropColor(0, 0, 0)
+
+	frame.Close = CreateFrame("Button", "$parentClose", frame)
+	frame.Close:SetSize(24, 24)
+	frame.Close:SetPoint("TOPRIGHT")
+	frame.Close:SetNormalTexture("Interface/Buttons/UI-Panel-MinimizeButton-Up")
+	frame.Close:SetPushedTexture("Interface/Buttons/UI-Panel-MinimizeButton-Down")
+	frame.Close:SetHighlightTexture("Interface/Buttons/UI-Panel-MinimizeButton-Highlight", "ADD")
+	frame.Close:SetScript("OnClick", function(widget)
+		widget:GetParent():Hide()
+	end)
+
+	frame.Messages = CreateFrame("ScrollingMessageFrame", "$parentMessages", frame)
+	frame.Messages:SetPoint("TOPLEFT", 15, -25)
+	frame.Messages:SetPoint("BOTTOMRIGHT", -30, 15)
+	frame.Messages:SetTextCopyable(true)
+	frame.Messages:EnableMouse(true)
+	frame.Messages:SetInsertMode(SCROLLING_MESSAGE_FRAME_INSERT_MODE_TOP)
+	frame.Messages:SetMaxLines(numSavedLines)
+	frame.Messages:SetFading(false)
+	frame.Messages:SetIndentedWordWrap(true)
+	frame.Messages:SetFontObject(ChatFontNormal)
+	frame.Messages:SetJustifyH("LEFT")
+
+	frame.Scroll = CreateFrame("ScrollFrame", "$parentScroll", frame, "FauxScrollFrameTemplate")
+	frame.Scroll:SetPoint("TOPLEFT", 15, -25)
+	frame.Scroll:SetPoint("BOTTOMRIGHT", -30, 15)
+	local function ScrollList(widget)
+		local offset = FauxScrollFrame_GetOffset(widget)
+		widget:GetParent().Messages:SetScrollOffset(offset)
+		FauxScrollFrame_Update(widget, numSavedLines, 25, 12)
+	end
+	frame.Scroll:SetScript("OnVerticalScroll", function(widget, offset)
+		FauxScrollFrame_OnVerticalScroll(widget, offset, 6, ScrollList)
+	end)
+
+	frame.Select = CreateFrame("Button", "$parentSelect", frame, "UIPanelButtonTemplate")
+	frame.Select:SetSize(180, 25)
+	frame.Select:SetPoint("RIGHT", frame.Close, "LEFT")
+	frame.Select:SetText("Copy ALL the things")
+	frame.Select:SetScale(0.85)
+	frame.Select:SetScript("OnClick", function()
+		local concatenatedMessages = DebugCache:GetCopyableMessageString()
+		CopyPastePopup:SetEditBoxText(concatenatedMessages)
+		CopyPastePopup:Show()
+	end)
+
+	frame:Hide()
+
+	self.frame = frame
+end
+
+function ScrollingDebugMessageFrame:AddMessage(message)
+	self.frame.Messages:AddMessage(message)
+
+	if not self.frame:IsShown() then
+		return -- No need to waste time updating an invisible frame
+	end
+
+	self:UpdateDisplayedMessages()
+end
+
+function ScrollingDebugMessageFrame:Toggle()
+	self.frame:SetShown(not self.frame:IsShown())
+end
+
+function ScrollingDebugMessageFrame:UpdateDisplayedMessages()
+	local numMessagesAvailable = self.frame.Messages:GetNumMessages()
+	FauxScrollFrame_Update(self.frame.Scroll, numMessagesAvailable, self.numMessagesToDisplay, 12)
+end
+
+Rarity.ScrollingDebugMessageFrame = ScrollingDebugMessageFrame
+
+ScrollingDebugMessageFrame:OnLoad()

--- a/Core/GUI/ScrollingDebugMessageFrame.lua
+++ b/Core/GUI/ScrollingDebugMessageFrame.lua
@@ -75,6 +75,16 @@ function ScrollingDebugMessageFrame:OnLoad()
 		CopyPastePopup:Show()
 	end)
 
+	frame.Clear = CreateFrame("Button", "$parentClear", frame, "UIPanelButtonTemplate")
+	frame.Clear:SetSize(180, 25)
+	frame.Clear:SetPoint("RIGHT", frame.Select, "LEFT")
+	frame.Clear:SetText("Clear ALL the things")
+	frame.Clear:SetScale(0.85)
+	frame.Clear:SetScript("OnClick", function()
+		DebugCache:Clear()
+		frame.Messages:Clear()
+	end)
+
 	frame:Hide()
 
 	self.frame = frame

--- a/README.MD
+++ b/README.MD
@@ -33,7 +33,7 @@
 <p>For troubleshooting issues:</p>
 <ul>
 <li><strong>/rarity mapinfo</strong> prints the current map name and ID, which can help track zonewide custom items</li>
-<li><strong>/rarity dump</strong> prints the most recent debug log entries (even if the debug mode is disabled)</li>
+<li><strong>/rarity dump</strong> displays the most recent debug log entries (even if the debug mode is disabled)</li>
 <li><strong>/rarity validate</strong> checks the consistency of your item database, including custom items (experimental)</li>
 </ul>
 <h2 id="w-http-www-wowace-com-addons-rarity-comments-http-www"><a href="http://www.wowace.com/addons/rarity/">Comments</a> &amp; <a href="http://www.wowace.com/addons/rarity/tickets/">bug reports</a></h2>

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -141,6 +141,7 @@ Core\Waypoints.lua
 # UI
 Core\GUI\AnchoredTrackingBar.lua
 Core\GUI\CopyPastePopup.lua
+Core\GUI\ScrollingDebugMessageFrame.lua
 Core\GUI\DataBrokerDisplay.lua
 Core\GUI\FauxAchievementPopup.lua
 Core\GUI\GameTooltipHooks.lua

--- a/Utils/DebugCache.lua
+++ b/Utils/DebugCache.lua
@@ -34,7 +34,7 @@ end
 -- Clears the debug stack, deleting all messages
 function DC:Clear()
 	self.messages = {}
-	self.print("Cleared messages")
+	self.print("Cleared all cached debug messages")
 end
 
 -- Prints number of cached debug messages to the output sink

--- a/Utils/DebugCache.lua
+++ b/Utils/DebugCache.lua
@@ -4,8 +4,11 @@ if not addon then
 end
 
 -- Upvalues
+local date = date
+local format = string.format
 local tostring = tostring
 local type = type
+local tconcat = table.concat
 local tinsert = table.insert
 local tremove = table.remove
 local time = time
@@ -81,6 +84,25 @@ function DC:AddMessage(text, category)
 		tremove(self.messages, 1)
 	end
 	tinsert(self.messages, message)
+
+	local formattedDate = self:GetHumanReadableDateString(message.timestamp)
+	local formattedLogLine = format("[%s] (%s) %s", formattedDate, message.category, message.text)
+	Rarity.ScrollingDebugMessageFrame:AddMessage(formattedLogLine)
+end
+
+function DC:GetHumanReadableDateString(timestamp)
+	timestamp = timestamp or time()
+	local dateTable = date("*t", timestamp)
+	local formattedDate = format(
+		"%04d-%02d-%02d %02d:%02d:%02d",
+		dateTable.year,
+		dateTable.month,
+		dateTable.day,
+		dateTable.hour,
+		dateTable.min,
+		dateTable.sec
+	)
+	return formattedDate
 end
 
 -- Prints the last X messages (defaults to one message if the 'numMessages' parameter is omitted)
@@ -102,6 +124,31 @@ function DC:PrintMessages(numMessages)
 		local line = "(" .. tostring(i) .. ") - " .. tostring(msg.text)
 		self.print(line, msg.timestamp, msg.category)
 	end
+end
+
+function DC:GetCopyableMessageString(numMessages)
+	numMessages = numMessages or self.cacheSize
+
+	if #self.messages == 0 then
+		return "No messages to display (debug cache is empty)"
+	end
+
+	-- Show at least one message, but no more than are currently cached. Default to one message if no parameter was given
+	numMessages = min(#self.messages, (type(numMessages) == "number" and numMessages > 0) and numMessages or 1)
+
+	-- Show most recent messages first
+	local firstIndex = max(#self.messages - numMessages, 1)
+	local lastIndex = #self.messages
+
+	local formattedLogLines = {}
+	for i = firstIndex, lastIndex do
+		local message = self.messages[i]
+		local formattedDate = self:GetHumanReadableDateString(message.timestamp)
+		local line = format("[%s] (%s) %s", formattedDate, message.category, message.text)
+		tinsert(formattedLogLines, line)
+	end
+
+	return tconcat(formattedLogLines, "\n")
 end
 
 Rarity.Utils.DebugCache = DC


### PR DESCRIPTION
It doesn't look great, but it's workable. Basic functionality only:

* Messages are automatically synchronized (pushed) by the debug cache
* A button exists to copy/paste everything in the log (yes, it's tiny... I was unable to make it bigger without breaking the UI)
* Another button exists to clear the debug log (cache and scroll frame contents)
* Individual portions of the log can also be copied manually (via mouse) - this is a bit wonky due to how scroll frames work?
* The window can be closed, although currently not by pressing ESC
* It also can't be moved or resize and doesn't have a title bar

Note: I repurposed the `/rarity dump` command since this does the same thing, only better. Might need renaming (later)?

If someone who knows more about the UI system than me wants to improve it, by all means go ahead. Otherwise, it'll do.

![image](https://github.com/WowRarity/Rarity/assets/16489133/46515eda-a3f7-424c-940d-0cea3d446cd1)
