### PR TITLE
Add the spell ID for Scavenging (Engineering) to the database

### DIFF
--- a/DB/Spells.lua
+++ b/DB/Spells.lua
@@ -76,6 +76,7 @@ Rarity.relevantSpells = {
 	[74522] = "Skinning",
 	[102216] = "Skinning",
 	[158756] = "Skinning",
+	[49383] = "Engineering - Scavenging",
 
 	-- Not tested (and disabled until they are needed)
 	-- [1804] = "Pick Lock",


### PR DESCRIPTION
Add Spell ID for the scavenging by engineers so that the scavenging of a tracked NPC would not count as an attempt.
Tested against Arachnoid Harvester.
Also tested that the scavenging spell ID is the same in different zones.
Fixes #644