### PR TITLE
Register a new keybind to toggle the debug UI

### DIFF
--- a/Bindings.xml
+++ b/Bindings.xml
@@ -1,0 +1,5 @@
+<Bindings>
+	<Binding name="RARITY_DEBUGWINDOWTOGGLE" category="Rarity">
+		Rarity.ScrollingDebugMessageFrame:Toggle()
+	</Binding>
+</Bindings>

--- a/Core.lua
+++ b/Core.lua
@@ -164,6 +164,10 @@ do
 		self:RegisterChatCommand("rarity", "OnChatCommand")
 		self:RegisterChatCommand("rare", "OnChatCommand")
 
+		-- Register keybind(s): These must match the info from Bindings.xml (and use localized descriptions)
+		_G.BINDING_HEADER_Rarity = "Rarity"
+		_G.BINDING_NAME_RARITY_DEBUGWINDOWTOGGLE = L["Toggle Debug Window"]
+
 		Rarity.GUI:RegisterDataBroker()
 
 		-- Expose private objects

--- a/Locales.lua
+++ b/Locales.lua
@@ -2,6 +2,7 @@ local L
 L = LibStub("AceLocale-3.0"):NewLocale("Rarity", "enUS", true)
 
 -- L["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] = true
+L["Toggle Debug Window"] = true
 L["Darkmoon Rabbit"] = true
 L["Disgusting Vat"] = true
 L["Fished from Disgusting Vat located within the Zskera Vaults"] = true


### PR DESCRIPTION
I can't seem to figure out why setting the header doesn't work if using the default ADDONS category, so I guess there will just be one more category for people to scroll past... Oh, well.