### PR TITLE
Prevent alerts from triggering for class-filtered items

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -668,11 +668,8 @@ function R:IsAttemptAllowed(item)
 	end
 
 	-- Check disabled classes
-	local playerClass = Rarity.Caching:GetPlayerClass() -- Why is this cached in the first place?
-	if not playerClass then
-		Rarity.Caching:SetPlayerClass(select(2, UnitClass("player")))
-	end
-	if item.disableForClass and type(item.disableForClass) == "table" and item.disableForClass[playerClass] == true then
+	local playerClass = select(2, UnitClass("player"))
+	if item.disableForClass and item.disableForClass[playerClass] then
 		Rarity:Debug(format("Attempts for item %s are disallowed (disabled for class %s)", item.name, playerClass))
 		return false
 	end

--- a/Core/Caching.lua
+++ b/Core/Caching.lua
@@ -6,7 +6,6 @@ local Caching = {}
 local IsInitializing = true
 local itemsPrimed = 0
 local itemsToPrime = 100
-local playerClass
 -- Upvalues
 local UnitFactionGroup = UnitFactionGroup
 
@@ -56,14 +55,6 @@ end
 
 function Caching:GetItemsToPrime()
 	return itemsToPrime
-end
-
-function Caching:GetPlayerClass()
-	return playerClass
-end
-
-function Caching:SetPlayerClass(class)
-	playerClass = class
 end
 
 Rarity.Caching = Caching

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -759,6 +759,12 @@ function R:OnItemFound(itemId, item)
 		return
 	end
 
+	local playerClass = select(2, UnitClass("player"))
+	if item.disableForClass and item.disableForClass[playerClass] then
+		Rarity:Debug(format("Ignoring OnItemFound trigger for item %s (disabled for class %s)", item.name, playerClass))
+		return
+	end
+
 	self:Debug("FOUND ITEM %d!", itemId)
 	if item.attempts == nil then
 		item.attempts = 1

--- a/Core/GUI/MainWindow.lua
+++ b/Core/GUI/MainWindow.lua
@@ -851,14 +851,8 @@ local function addGroup(group, requiresGroup)
 			)
 		then
 			local classGood = true
-			if not Rarity.Caching:GetPlayerClass() then
-				Rarity.Caching:SetPlayerClass(select(2, UnitClass("player")))
-			end
-			if
-				v.disableForClass
-				and type(v.disableForClass == "table")
-				and v.disableForClass[Rarity.Caching:GetPlayerClass()] == true
-			then
+			local playerClass = select(2, UnitClass("player"))
+			if v.disableForClass and v.disableForClass[playerClass] then
 				classGood = false
 			end
 


### PR DESCRIPTION
When an item is disabled for the player's class, attempts are successfully blocked (via `IsAttemptAllowed`). However, the alert may still trigger when any such item is added to the inventory, in which case the item would be incorrectly "checked off" (untracked).