### PR TITLE
Fix the keybinding category in Bindings.xml

### DIFF
--- a/Bindings.xml
+++ b/Bindings.xml
@@ -1,5 +1,5 @@
 <Bindings>
-	<Binding name="RARITY_DEBUGWINDOWTOGGLE" category="Rarity">
+	<Binding name="RARITY_DEBUGWINDOWTOGGLE" category="BINDING_HEADER_Rarity">
 		Rarity.ScrollingDebugMessageFrame:Toggle()
 	</Binding>
 </Bindings>


### PR DESCRIPTION
Reported on Discord by michael (mikuhl_). Thanks!

`_G.Rarity` "accidentally" works because AceAddon adds a `__tostring` metamethod, but it's not the right way to get there obviously.