### PR TITLE
Add kill statistics for Reins of the Quantum Courser

### DIFF
--- a/DB/Toys/Dragonflight.lua
+++ b/DB/Toys/Dragonflight.lua
@@ -311,6 +311,7 @@ local dragonflightToys = {
 			199000, -- Chrono-Lord Deios
 		},
 		chance = 50,
+		statisticId = { 16097 },
 		coords = {
 			{ m = CONSTANTS.UIMAPIDS.CROSSROADS_OF_FATE },
 		},


### PR DESCRIPTION
This should work in Mythic+ keystone dungeons as well, or at least that's how the BFA mounts are configured.