### PR TITLE
Update the database entry for Reins of the Quantum Courser

### DIFF
--- a/DB/Toys/Dragonflight.lua
+++ b/DB/Toys/Dragonflight.lua
@@ -313,7 +313,7 @@ local dragonflightToys = {
 		chance = 50,
 		statisticId = { 16097 },
 		coords = {
-			{ m = CONSTANTS.UIMAPIDS.CROSSROADS_OF_FATE },
+			{ m = CONSTANTS.UIMAPIDS.CROSSROADS_OF_FATE, i = true },
 		},
 	},
 	["Fyrakk's Frenzy"] = {

--- a/DB/Toys/Dragonflight.lua
+++ b/DB/Toys/Dragonflight.lua
@@ -312,6 +312,7 @@ local dragonflightToys = {
 		},
 		chance = 50,
 		statisticId = { 16097 },
+		instanceDifficulties = { [CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true },
 		lockoutDetails = {
 			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
 			{

--- a/DB/Toys/Dragonflight.lua
+++ b/DB/Toys/Dragonflight.lua
@@ -312,6 +312,13 @@ local dragonflightToys = {
 		},
 		chance = 50,
 		statisticId = { 16097 },
+		lockoutDetails = {
+			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
+			{
+				encounterName = "Chrono-Lord Deios",
+				instanceDifficulties = { [CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true },
+			},
+		},
 		coords = {
 			{ m = CONSTANTS.UIMAPIDS.CROSSROADS_OF_FATE, i = true },
 		},


### PR DESCRIPTION
Adds the missing defeat detection settings and should now prevent attempts on Heroic difficulty, as wowhead says it's Mythic-only.