### PR TITLE
Added Falling Star Flinger and Falling Star Catcher (toys)

### DIFF
--- a/DB/Toys/HolidayEvents.lua
+++ b/DB/Toys/HolidayEvents.lua
@@ -454,6 +454,32 @@ local holidayEventToys = {
 		questId = { 6983, 7043 },
 		coords = { { m = CONSTANTS.UIMAPIDS.HILLSBRAD_FOOTHILLS, x = 43.6, y = 39.6 } },
 	},
+	["Falling Star Flinger"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Falling Star Flinger"],
+		itemId = 191925,
+		items = { 116762 },
+		chance = 100, -- Blind guess
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		questId = { 6983, 7043 },
+		coords = { { m = CONSTANTS.UIMAPIDS.HILLSBRAD_FOOTHILLS, x = 43.6, y = 39.6 } },
+	},
+	["Falling Star Catcher"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
+		type = CONSTANTS.ITEM_TYPES.ITEM,
+		isToy = true,
+		method = CONSTANTS.DETECTION_METHODS.USE,
+		name = L["Falling Star Catcher"],
+		itemId = 191937,
+		items = { 116762 },
+		chance = 100, -- Blind guess
+		holidayTexture = CONSTANTS.HOLIDAY_TEXTURES.WINTERS_VEIL,
+		questId = { 6983, 7043 },
+		coords = { { m = CONSTANTS.UIMAPIDS.HILLSBRAD_FOOTHILLS, x = 43.6, y = 39.6 } },
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.toys, holidayEventToys)

--- a/Locales.lua
+++ b/Locales.lua
@@ -2,6 +2,8 @@ local L
 L = LibStub("AceLocale-3.0"):NewLocale("Rarity", "enUS", true)
 
 -- L["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] = true
+L["Falling Star Catcher"] = true
+L["Falling Star Flinger"] = true
 L["Festive Trans-Dimensional Bird Whistle"] = true
 L["Moltenbinder's Disciple"] = true
 L["Molten Lava Ball"] = true


### PR DESCRIPTION
According to wowhead, these 2022 Winter Veil rewards are now obtainable from Stolen Presents... As is tradition?