### PR TITLE
Add Clayscale Hornstrider (mount) to the item database

### DIFF
--- a/DB/Mounts/Dragonflight.lua
+++ b/DB/Mounts/Dragonflight.lua
@@ -300,6 +300,18 @@ local dragonflightMounts = {
 		sourceText = L["This item can also be purchased from a vendor."],
 		coords = { { m = CONSTANTS.UIMAPIDS.THE_EMERALD_DREAM } },
 	},
+	-- 10.2.5
+	["Clayscale Hornstrider"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.DRAGONFLIGHT,
+		type = CONSTANTS.ITEM_TYPES.MOUNT,
+		method = CONSTANTS.DETECTION_METHODS.NPC,
+		name = L["Clayscale Hornstrider"],
+		spellId = 432610,
+		itemId = 212645,
+		npcs = { 208029 },
+		chance = 200,
+		coords = { { m = CONSTANTS.UIMAPIDS.THE_AZURE_SPAN } },
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.mounts, dragonflightMounts)

--- a/Locales.lua
+++ b/Locales.lua
@@ -2,6 +2,7 @@ local L
 L = LibStub("AceLocale-3.0"):NewLocale("Rarity", "enUS", true)
 
 -- L["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] = true
+L["Clayscale Hornstrider"] = true
 L["Falling Star Catcher"] = true
 L["Falling Star Flinger"] = true
 L["Festive Trans-Dimensional Bird Whistle"] = true


### PR DESCRIPTION
This also seems to be obtainable from containers, but the addon doesn't currently support multiple sources for a single item.

Will have to look into that eventually, but having the dig site boss be tracked is likely better than no tracking at all.