### PR TITLE
Remove the statistic ID for Quantum Courser

### DIFF
--- a/DB/Toys/Dragonflight.lua
+++ b/DB/Toys/Dragonflight.lua
@@ -311,7 +311,6 @@ local dragonflightToys = {
 			199000, -- Chrono-Lord Deios
 		},
 		chance = 50,
-		statisticId = { 16097 },
 		instanceDifficulties = { [CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_DUNGEON] = true },
 		lockoutDetails = {
 			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,


### PR DESCRIPTION
The boss appears in two dungeons, and this statistic is for the alternate version (which doesn't drop the mount). Unfortunately, there's no statistic for the "right" version that could be used.

This fixes the tracking for Quantum Courser, which has been reported as broken by multiple people. It seems that I originally added the wrong statistic because wowhead didn't display the dungeon name? Or maybe I misread, who knows.