### PR TITLE
Register the options UI with Blizzard's Addon Compartment

### DIFF
--- a/Core/Interoperability/Blizzard/AddonCompartment.lua
+++ b/Core/Interoperability/Blizzard/AddonCompartment.lua
@@ -1,15 +1,25 @@
+local L = LibStub("AceLocale-3.0"):GetLocale("Rarity")
+
 local AddonCompartment = {}
 
 function AddonCompartment.OnClick()
-	print("[Placeholder] Rarity.AddonCompartment.OnClick triggered")
+	-- Should behave the same as the default /rarity slash command (copy/pasted for now) - improve UX later?
+	LoadAddOn("Rarity_Options")
+	if Rarity.optionsFrame then
+		-- Thanks, Blizzard (https://www.wowinterface.com/forums/showthread.php?t=54599)
+		InterfaceOptionsFrame_OpenToCategory(Rarity.optionsFrame)
+		InterfaceOptionsFrame_OpenToCategory(Rarity.optionsFrame)
+	else
+		Rarity:Print(L["The Rarity Options module has been disabled. Log out and enable it from your add-ons menu."])
+	end
 end
 
 function AddonCompartment.OnEnter()
-	print("[Placeholder] Rarity.AddonCompartment.OnEnter triggered")
+	-- Might want to display a tooltip here if the behavior differs from the default /rarity slash command
 end
 
 function AddonCompartment.OnLeave()
-	print("[Placeholder] Rarity.AddonCompartment.OnLeave triggered")
+	-- Might want to display a tooltip here if the behavior differs from the default /rarity slash command
 end
 
 -- No way around polluting the global namespace for these, AFAICT

--- a/Core/Interoperability/Blizzard/AddonCompartment.lua
+++ b/Core/Interoperability/Blizzard/AddonCompartment.lua
@@ -1,0 +1,20 @@
+local AddonCompartment = {}
+
+function AddonCompartment.OnClick()
+	print("[Placeholder] Rarity.AddonCompartment.OnClick triggered")
+end
+
+function AddonCompartment.OnEnter()
+	print("[Placeholder] Rarity.AddonCompartment.OnEnter triggered")
+end
+
+function AddonCompartment.OnLeave()
+	print("[Placeholder] Rarity.AddonCompartment.OnLeave triggered")
+end
+
+-- No way around polluting the global namespace for these, AFAICT
+_G.Rarity_OnAddonCompartmentClick = AddonCompartment.OnClick
+_G.Rarity_OnAddonCompartmentEnter = AddonCompartment.OnEnter
+_G.Rarity_OnAddonCompartmentLeave = AddonCompartment.OnLeave
+
+Rarity.AddonCompartment = AddonCompartment

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -20,6 +20,7 @@
 ## AddonCompartmentFunc: Rarity_OnAddonCompartmentClick
 ## AddonCompartmentFuncOnEnter: Rarity_OnAddonCompartmentEnter
 ## AddonCompartmentFuncOnLeave: Rarity_OnAddonCompartmentLeave
+## IconTexture: Interface\Icons\spell_nature_forceofnature.blp
 
 ## LoadManagers: AddonLoader
 ## OptionalDeps: Ace3,LibDualSpec-1.0,LibQTip-1.0,LibDBIcon-1.0,LibBabble-Zone-3.0,LibSink-2.0,LibBabble-SubZone-3.0,LibSharedMedia-3.0,AceGUI-3.0-SharedMediaWidgets,LibBabble-CreatureType-3.0,LibBabble-Boss-3.0,HereBeDragons

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -17,6 +17,10 @@
 ## Notes-itIT: @localization(locale="itIT", key="Notes", namespace="ToC - Table of Contents")@
 ## Notes-frFR: @localization(locale="frFR", key="Notes", namespace="ToC - Table of Contents")@
 
+## AddonCompartmentFunc: Rarity_OnAddonCompartmentClick
+## AddonCompartmentFuncOnEnter: Rarity_OnAddonCompartmentEnter
+## AddonCompartmentFuncOnLeave: Rarity_OnAddonCompartmentLeave
+
 ## LoadManagers: AddonLoader
 ## OptionalDeps: Ace3,LibDualSpec-1.0,LibQTip-1.0,LibDBIcon-1.0,LibBabble-Zone-3.0,LibSink-2.0,LibBabble-SubZone-3.0,LibSharedMedia-3.0,AceGUI-3.0-SharedMediaWidgets,LibBabble-CreatureType-3.0,LibBabble-Boss-3.0,HereBeDragons
 ## SavedVariables: RarityDB
@@ -118,6 +122,7 @@ Core\Interoperability\TradeSkillMaster\AuctionDB.lua
 Core\Interoperability\WoWUnit\Testing.lua
 
 # Wrappers for the WOW API (to provide a consistent API)
+Core\Interoperability\Blizzard\AddonCompartment.lua
 Core\Interoperability\Blizzard\MapInfo.lua
 
 # Addon Core


### PR DESCRIPTION
Resolves #660. Improvements can be made later, for now this is behaving the same way as the default `/rarity` slash command.