### PR TITLE
Implement Area POI handling for Elemental Storm events

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -719,6 +719,11 @@ function R:IsAttemptAllowed(item)
 		end
 	end
 
+	if not Rarity.AreaPOIs.HasActiveAreaPOIs(item.requiredAreaPOIs) then
+		Rarity:Debug(format("Attempts for item %s are disallowed (requires active area POIs)", item.name))
+		return false
+	end
+
 	-- No valid instance difficulty configuration; allow (this needs to be the second-to-last check)
 	if
 		item.instanceDifficulties == nil

--- a/Core/Interoperability/Blizzard/AreaPOIs.lua
+++ b/Core/Interoperability/Blizzard/AreaPOIs.lua
@@ -1,0 +1,28 @@
+local L = LibStub("AceLocale-3.0"):GetLocale("Rarity")
+
+local GetAreaPOIInfo = C_AreaPoiInfo.GetAreaPOIInfo
+local GetBestMapForUnit = C_Map.GetBestMapForUnit
+
+local format = string.format
+local ipairs = ipairs
+
+local AreaPOIs = {}
+
+function AreaPOIs.HasActiveAreaPOIs(areaPOIs)
+	if not areaPOIs then
+		return false
+	end
+
+	local currentMapID = GetBestMapForUnit("player")
+	for index, areaPointOfInterestID in ipairs(areaPOIs) do
+		local info = GetAreaPOIInfo(currentMapID, areaPointOfInterestID)
+		if info ~= nil then
+			Rarity:Debug(format("Detected active area POI %d", areaPointOfInterestID))
+			return true
+		end
+	end
+
+	return false
+end
+
+Rarity.AreaPOIs = AreaPOIs

--- a/DB/Pets/Dragonflight.lua
+++ b/DB/Pets/Dragonflight.lua
@@ -272,11 +272,11 @@ local dragonflightPets = {
 		method = CONSTANTS.DETECTION_METHODS.NPC,
 		name = L["Echo of the Heights"],
 		npcs = {
-			203746,
-			203744,
-			203743,
-			203745,
-			203747,
+			203743, -- Air Revenant
+			203744, -- Primalist Galewarden
+			203745, -- Primalist Stormchanter
+			203746, -- Primalist Stormslinger
+			203747, -- Water Elemental
 			193967,
 			201556,
 			194119,
@@ -412,9 +412,7 @@ local dragonflightPets = {
 			187923,
 			195448,
 			186604,
-			203754,
 			188044,
-			203755,
 			188009,
 			187928,
 			186612,
@@ -428,15 +426,10 @@ local dragonflightPets = {
 			186628,
 			186624,
 			197139,
-			203748,
-			203753,
 			196772,
 			186783,
 			190991,
-			203756,
-			203750,
 			195837,
-			203741,
 			195814,
 			186638,
 			187889,
@@ -445,7 +438,6 @@ local dragonflightPets = {
 			191637,
 			186626,
 			186684,
-			203740,
 			186109,
 			186792,
 		},
@@ -467,10 +459,10 @@ local dragonflightPets = {
 		method = CONSTANTS.DETECTION_METHODS.NPC,
 		name = L["Echo of the Depths"],
 		npcs = {
-			203750,
-			203752,
-			203748,
-			203747,
+			203747, -- Water Elemental
+			203748, -- Primalist Flowbreaker
+			203750, -- Primalist Iceslinger
+			203752, -- Ice Elemental
 			197169,
 			201540,
 			192334,
@@ -579,7 +571,6 @@ local dragonflightPets = {
 			201557,
 			186620,
 			197902,
-			203757,
 			190780,
 			187600,
 			190776,
@@ -625,15 +616,9 @@ local dragonflightPets = {
 			186628,
 			186624,
 			186626,
-			203745,
 			188044,
-			203756,
 			197356,
-			203754,
-			203753,
 			203744,
-			203743,
-			203742,
 			187928,
 			186239,
 			188014,
@@ -642,7 +627,6 @@ local dragonflightPets = {
 			191479,
 			197139,
 			186684,
-			203739,
 			186109,
 		},
 		itemId = 200260,
@@ -663,11 +647,11 @@ local dragonflightPets = {
 		method = CONSTANTS.DETECTION_METHODS.NPC,
 		name = L["Echo of the Inferno"],
 		npcs = {
-			203753,
-			203755,
-			203756,
-			203757,
-			203754,
+			203753, -- Primalist Flamestriker
+			203754, -- Primalist Fireslinger
+			203755, -- Lava Fury
+			203756, -- Fire Revenant
+			203757, -- Lava Elemental
 			186859,
 			192696,
 			191507,
@@ -804,9 +788,7 @@ local dragonflightPets = {
 			187923,
 			195448,
 			207337,
-			203747,
 			194798,
-			203741,
 			191363,
 			195815,
 			197136,
@@ -818,14 +800,10 @@ local dragonflightPets = {
 			197139,
 			186626,
 			191637,
-			203739,
 			203744,
-			203750,
-			203745,
 			186638,
 			192371,
 			186792,
-			203743,
 			186599,
 			191672,
 			185350,
@@ -853,10 +831,10 @@ local dragonflightPets = {
 		method = CONSTANTS.DETECTION_METHODS.NPC,
 		name = L["Echo of the Cave"],
 		npcs = {
-			203741,
-			203739,
-			203740,
-			203742,
+			203739, -- Primalist Earthrazer
+			203740, -- Primalist Landshaker
+			203741, -- Stone Elemental
+			203742, -- Earth Revenant
 			197092,
 			197091,
 			197169,
@@ -1016,17 +994,10 @@ local dragonflightPets = {
 			203744,
 			191479,
 			186684,
-			203748,
-			203752,
-			203754,
-			203750,
-			203747,
-			203743,
 			197356,
 			186624,
 			188014,
 			199298,
-			203753,
 			186109,
 			186792,
 		},

--- a/DB/Pets/Dragonflight.lua
+++ b/DB/Pets/Dragonflight.lua
@@ -441,6 +441,19 @@ local dragonflightPets = {
 			186109,
 			186792,
 		},
+		requiredAreaPOIs = {
+			7221, -- Elemental Storm (Air) - Nokhuud Hold
+			7225, -- Elemental Storm (Air) - Ohn'iri Springs
+			7229, -- Elemental Storm (Air) - Brackenhide Hollow
+			7233, -- Elemental Storm (Air) - Cobalt Assembly
+			7237, -- Elemental Storm (Air) - Imbu
+			7241, -- Elemental Storm (Air) - Unnamed Area
+			7245, -- Elemental Storm (Air) - Tyrhold
+			7249, -- Elemental Storm (Air) - Dragonbane Keep
+			7253, -- Elemental Storm (Air) - Slagmire
+			7257, -- Elemental Storm (Air) - Scalecracker Keep
+			7298, -- Elemental Storm (Air) - Primalist Future
+		},
 		itemId = 200263,
 		spellId = 389384,
 		chance = 1000,
@@ -629,6 +642,19 @@ local dragonflightPets = {
 			186684,
 			186109,
 		},
+		requiredAreaPOIs = {
+			7224, -- Elemental Storm (Water) - Nokhuud Hold
+			7228, -- Elemental Storm (Water) - Ohn'iri Springs
+			7232, -- Elemental Storm (Water) - Brackenhide Hollow
+			7236, -- Elemental Storm (Water) - Cobalt Assembly
+			7240, -- Elemental Storm (Water) - Imbu
+			7244, -- Elemental Storm (Water) - Unnamed Area
+			7248, -- Elemental Storm (Water) - Tyrhold
+			7252, -- Elemental Storm (Water) - Dragonbane Keep
+			7256, -- Elemental Storm (Water) - Slagmire
+			7260, -- Elemental Storm (Water) - Scalecracker Keep
+			7301, -- Elemental Storm (Water) - Primalist Future
+		},
 		itemId = 200260,
 		spellId = 389378,
 		chance = 1000,
@@ -812,6 +838,19 @@ local dragonflightPets = {
 			186624,
 			186684,
 			191479,
+		},
+		requiredAreaPOIs = {
+			7223, -- Elemental Storm (Fire) - Nokhuud Hold
+			7227, -- Elemental Storm (Fire) - Ohn'iri Springs
+			7231, -- Elemental Storm (Fire) - Brackenhide Hollow
+			7235, -- Elemental Storm (Fire) - Cobalt Assembly
+			7239, -- Elemental Storm (Fire) - Imbu
+			7243, -- Elemental Storm (Fire) - Unnamed Area
+			7247, -- Elemental Storm (Fire) - Tyrhold
+			7251, -- Elemental Storm (Fire) - Dragonbane Keep
+			7255, -- Elemental Storm (Fire) - Slagmire
+			7259, -- Elemental Storm (Fire) - Scalecracker Keep
+			7300, -- Elemental Storm (Fire) - Primalist Future
 		},
 		itemId = 200255,
 		spellId = 389363,
@@ -1000,6 +1039,19 @@ local dragonflightPets = {
 			199298,
 			186109,
 			186792,
+		},
+		requiredAreaPOIs = {
+			7222, -- Elemental Storm (Earth) - Nokhuud Hold
+			7226, -- Elemental Storm (Earth) - Ohn'iri Springs
+			7230, -- Elemental Storm (Earth) - Brackenhide Hollow
+			7234, -- Elemental Storm (Earth) - Cobalt Assembly
+			7238, -- Elemental Storm (Earth) - Imbu
+			7242, -- Elemental Storm (Earth) - Unnamed Area
+			7246, -- Elemental Storm (Earth) - Tyrhold
+			7250, -- Elemental Storm (Earth) - Dragonbane Keep
+			7254, -- Elemental Storm (Earth) - Slagmire
+			7258, -- Elemental Storm (Earth) - Scalecracker Keep
+			7299, -- Elemental Storm (Earth) - Primalist Future
 		},
 		itemId = 200183,
 		spellId = 389143,

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -124,6 +124,7 @@ Core\Interoperability\WoWUnit\Testing.lua
 
 # Wrappers for the WOW API (to provide a consistent API)
 Core\Interoperability\Blizzard\AddonCompartment.lua
+Core\Interoperability\Blizzard\AreaPOIs.lua
 Core\Interoperability\Blizzard\MapInfo.lua
 
 # Addon Core


### PR DESCRIPTION
This approach has two limitations/issues; see commit messages for details. They aren't critical, so this can already be merged.

1. Elementals that persist after the storm has ended won't add attempts unless their storm event is currently active
2. The event is detected mapwide, so technically all sites will be "enabled" (and add attempts) while it's active

I think the first issue can probably be ignored, and the second may warrant a second look if it turns out to be a problem (later).