### PR TITLE
Fix an oversight in the Area POI detection

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -719,7 +719,7 @@ function R:IsAttemptAllowed(item)
 		end
 	end
 
-	if not Rarity.AreaPOIs.HasActiveAreaPOIs(item.requiredAreaPOIs) then
+	if item.requiredAreaPOIs and not Rarity.AreaPOIs.HasActiveAreaPOIs(item.requiredAreaPOIs) then
 		Rarity:Debug(format("Attempts for item %s are disallowed (requires active area POIs)", item.name))
 		return false
 	end


### PR DESCRIPTION
When an item doesn't require active Area POIs, which is the case for almost all items in the database, the field should simply be ignored. The code currently specifies that attempts should be disallowed in this case, which is clearly wrong (and I missed it).

I think the reason for this is somewhat poor naming of `HasActiveAreaPOIs` - it detects whether the current map has active area POIs AND whether the given list of POIs contains an entry that is currently active. This is arguably not immediately obvious, but there are other issues that need fixing also. Might need a rework the POI code to fix #721 (deferred for now).