### PR TITLE
Fix the encounter name for Vengeance's Reins

### DIFF
--- a/DB/Mounts/Shadowlands.lua
+++ b/DB/Mounts/Shadowlands.lua
@@ -615,7 +615,7 @@ local shadowlandsMounts = {
 		lockoutDetails = {
 			mode = CONSTANTS.DEFEAT_DETECTION.MODE_AND,
 			{
-				encounterName = "Lady Sylvanas Windrunner",
+				encounterName = "Sylvanas Windrunner",
 				instanceDifficulties = {
 					[CONSTANTS.INSTANCE_DIFFICULTIES.MYTHIC_RAID] = true,
 				},


### PR DESCRIPTION
The name displayed by wowhead doesn't match the one used ingame.