### PR TITLE
Add support for zero length auto-hide delays

### DIFF
--- a/Core/GUI/MainWindow.lua
+++ b/Core/GUI/MainWindow.lua
@@ -1416,7 +1416,8 @@ function R:ShowTooltip(hidden)
 	showedHolidayReminderOverflow = false
 	local delay
 	if self.db.profile.tooltipHideDelay <= 0 then
-		delay = 0.01
+		local hideOnClick = (Rarity.db.profile.tooltipActivation == CONSTANTS.TOOLTIP.ACTIVATION_METHOD_CLICK)
+		delay = hideOnClick and 0 or 0.01 -- Hiding manually is only possible when not in hover mode
 	else
 		delay = self.db.profile.tooltipHideDelay or 0.6
 	end


### PR DESCRIPTION
As requested on Discord, this allows toggling the main window when setting an auto-hide delay of zero ("forever"), but only when using clicks to activate the window. In hover mode there's no way to hide the window again, so the original fallback was kept.