### PR TITLE
Enable the TOC version check script to process comma-separated lists

### DIFF
--- a/.github/check-interface-versions.sh
+++ b/.github/check-interface-versions.sh
@@ -2,7 +2,7 @@ local_version=$(cat Rarity.toc | grep -oP '## Interface: \K\d+')
 options_version=$(cat Modules/Options/Rarity_Options.toc | grep -oP '## Interface: \K\d+')
 
 # Since there's no "official" way to get the latest version, just use a popular/frequently updated addon ...
-remote_version=$(curl https://raw.githubusercontent.com/BigWigsMods/BigWigs/master/BigWigs.toc --silent | grep -oP '## Interface: \K\d+')
+remote_version=$(curl https://raw.githubusercontent.com/BigWigsMods/BigWigs/master/BigWigs.toc --silent | grep -oP '## Interface:.*' | grep -oP '\d+' | sort -nr | head -n 1)
 
 if [ "$local_version" != "$remote_version" ]; then
     echo "Local interface version ($local_version) is not up to date with remote version ($remote_version)"

--- a/Modules/Options/Rarity_Options.toc
+++ b/Modules/Options/Rarity_Options.toc
@@ -1,6 +1,6 @@
 ## Author: Allara
-## Interface: 100207
-## X-Min-Interface: 100207
+## Interface: 110002
+## X-Min-Interface: 110002
 ## Notes: Rarity configuration. Use AddonLoader to load this on demand.
 ## Title: Rarity [|caaedc99fOptions|r]
 ## Dependencies: Rarity

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -1,6 +1,6 @@
 ## Author: Allara
-## Interface: 100207
-## X-Min-Interface: 100207
+## Interface: 110002
+## X-Min-Interface: 110002
 ## Title: Rarity
 ## Version: 1.0 (@project-version@)
 ## X-Curse-Project-ID: 30801


### PR DESCRIPTION
Piling more hacks onto this sketchy script, it now extracts the highest (latest) version number if there are multiple listed.

I don't expect the approach to be any less brittle, but at least it should again function as an alert in case of outdated TOC versions.