### PR TITLE
Upgrade the format check to use stylua-action v4

### DIFF
--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up StyLua
-        uses: JohnnyMorganz/stylua-action@v2.0.0
+        uses: JohnnyMorganz/stylua-action@v4.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --check . --verbose


### PR DESCRIPTION
V2 triggers a deprecation warning in the GitHub UI.