### PR TITLE
Add an IconTexture for the Options module

### DIFF
--- a/Modules/Options/Rarity_Options.toc
+++ b/Modules/Options/Rarity_Options.toc
@@ -9,4 +9,6 @@
 ## X-LoadOn-Slash: /rarity, /rare
 ## X-LoadOn-InterfaceOptions: Rarity
 
+## IconTexture: Interface\Icons\spell_nature_forceofnature.blp
+
 Options.lua


### PR DESCRIPTION
The ingame menu currently displays a default "question mark" icon. For consistency, use the same icon as the core addon.