### PR TITLE
Migrate the Options module from AddOnLoader to LoadOnDemand

### DIFF
--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -105,9 +105,7 @@ do
 		R.modulesEnabled.options = true
 
 		R:PrepareOptions()
-		if AddonLoader and AddonLoader.RemoveInterfaceOptions then
-			AddonLoader:RemoveInterfaceOptions("Rarity")
-		end
+
 		LibStub("AceConfig-3.0"):RegisterOptionsTable("Rarity", R.options)
 		R.optionsFrame = LibStub("AceConfigDialog-3.0"):AddToBlizOptions("Rarity", "Rarity")
 		R.profileOptions = LibStub("AceDBOptions-3.0"):GetOptionsTable(R.db)

--- a/Modules/Options/Rarity_Options.toc
+++ b/Modules/Options/Rarity_Options.toc
@@ -5,7 +5,7 @@
 ## Title: Rarity [|caaedc99fOptions|r]
 ## Dependencies: Rarity
 ## X-Part-Of: Rarity
-## LoadManagers: AddonLoader
+## LoadOnDemand: 1
 ## X-LoadOn-Slash: /rarity, /rare
 ## X-LoadOn-InterfaceOptions: Rarity
 

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -22,7 +22,6 @@
 ## AddonCompartmentFuncOnLeave: Rarity_OnAddonCompartmentLeave
 ## IconTexture: Interface\Icons\spell_nature_forceofnature.blp
 
-## LoadManagers: AddonLoader
 ## OptionalDeps: Ace3,LibDualSpec-1.0,LibQTip-1.0,LibDBIcon-1.0,LibBabble-Zone-3.0,LibSink-2.0,LibBabble-SubZone-3.0,LibSharedMedia-3.0,AceGUI-3.0-SharedMediaWidgets,LibBabble-CreatureType-3.0,LibBabble-Boss-3.0,HereBeDragons
 ## SavedVariables: RarityDB
 ## X-LoadOn-Always: delayed


### PR DESCRIPTION
Removes ancient optional dependency to manage loading the options, blizzard allows addons to set a LoadOnDemand field in the toc for this.