### PR TITLE
Add tracking for Awakened Caches

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -1777,6 +1777,11 @@ function R:OnLootReady(event, ...)
 			end
 		end
 
+		if Rarity.isOpening and Rarity.lastNode and Rarity.lastNode == L["Awakened Cache"] then
+			Rarity:Debug("Detected Opening on " .. Rarity.lastNode .. " (method = SPECIAL)")
+			addAttemptForItem("Machine Defense Unit 1-11", "mounts")
+		end
+
 		-- Handle opening Opera Chest (Holoviewers)
 		if Rarity.isFishing and Rarity.isOpening and Rarity.lastNode and (Rarity.lastNode == L["Opera Chest"]) then
 			local names = { "Holoviewer: The Timeless One", "Holoviewer: The Lady of Dreams" }

--- a/DB/Mounts/TheWarWithin.lua
+++ b/DB/Mounts/TheWarWithin.lua
@@ -77,6 +77,16 @@ local twwMounts = {
 		chance = 100, -- No data available
 		coords = { { m = CONSTANTS.UIMAPIDS.HALLOWFALL } },
 	},
+	["Machine Defense Unit 1-11"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.TWW,
+		type = CONSTANTS.ITEM_TYPES.MOUNT,
+		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+		name = L["Machine Defense Unit 1-11"],
+		itemId = 223269,
+		spellId = 448188,
+		chance = 5,
+		coords = { { m = CONSTANTS.UIMAPIDS.THE_RINGING_DEEPS } },
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.mounts, twwMounts)

--- a/DB/Nodes.lua
+++ b/DB/Nodes.lua
@@ -277,4 +277,5 @@ R.opennodes = {
 	[L["Obsidian Grand Cache"]] = true,
 	[L["Frozen Coffer"]] = true,
 	[L["Dreamseed Cache"]] = true,
+	[L["Awakened Cache"]] = true,
 }

--- a/Locales.lua
+++ b/Locales.lua
@@ -2,6 +2,7 @@ local L
 L = LibStub("AceLocale-3.0"):NewLocale("Rarity", "enUS", true)
 
 -- L["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] = true
+L["Machine Defense Unit 1-11"] = true
 L["Malfunctioning Mechsuit"] = true
 L["Dauntless Imperial Lynx"] = true
 L["Bop"] = true

--- a/Locales.lua
+++ b/Locales.lua
@@ -2,6 +2,7 @@ local L
 L = LibStub("AceLocale-3.0"):NewLocale("Rarity", "enUS", true)
 
 -- L["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] = true
+L["Awakened Cache"] = true
 L["Machine Defense Unit 1-11"] = true
 L["Malfunctioning Mechsuit"] = true
 L["Dauntless Imperial Lynx"] = true


### PR DESCRIPTION
Apparently these drop Machine Defense Unit 1-11 on live servers, which used to be listed as an achievement reward.