### PR TITLE
Add tracking for battle pets from 10.x Delves

### DIFF
--- a/DB/Pets/TheWarWithin.lua
+++ b/DB/Pets/TheWarWithin.lua
@@ -30,6 +30,76 @@ local twwPets = {
 		chance = 20, -- No data available
 		creatureId = 222359,
 	},
+	["Bouncer"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.TWW,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+		name = L["Bouncer"],
+		itemId = 222971,
+		spellId = 446434,
+		creatureId = 222532,
+		chance = 100,
+		coords = {
+			{ i = true, m = CONSTANTS.UIMAPIDS.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA },
+			{ i = true, m = CONSTANTS.UIMAPIDS.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA },
+		},
+	},
+	["Wriggle"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.TWW,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+		name = L["Wriggle"],
+		itemId = 221496,
+		spellId = 446464,
+		creatureId = 222078,
+		chance = 100,
+		coords = {
+			{ i = true, m = CONSTANTS.UIMAPIDS.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA },
+			{ i = true, m = CONSTANTS.UIMAPIDS.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA },
+		},
+	},
+	["Chester"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.TWW,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+		name = L["Chester"],
+		itemId = 221820,
+		spellId = 447016,
+		creatureId = 222883,
+		chance = 100,
+		coords = {
+			{ i = true, m = CONSTANTS.UIMAPIDS.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA },
+			{ i = true, m = CONSTANTS.UIMAPIDS.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA },
+		},
+	},
+	["Violet Sporbit"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.TWW,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+		name = L["Violet Sporbit"],
+		itemId = 225337,
+		spellId = 446498,
+		creatureId = 222590,
+		chance = 100,
+		coords = {
+			{ i = true, m = CONSTANTS.UIMAPIDS.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA },
+			{ i = true, m = CONSTANTS.UIMAPIDS.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA },
+		},
+	},
+	["Sneef"] = {
+		cat = CONSTANTS.ITEM_CATEGORIES.TWW,
+		type = CONSTANTS.ITEM_TYPES.PET,
+		method = CONSTANTS.DETECTION_METHODS.SPECIAL,
+		name = L["Sneef"],
+		itemId = 223624,
+		spellId = 449475,
+		creatureId = 223718,
+		chance = 100,
+		coords = {
+			{ i = true, m = CONSTANTS.UIMAPIDS.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA },
+			{ i = true, m = CONSTANTS.UIMAPIDS.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA },
+		},
+	},
 }
 
 Rarity.ItemDB.MergeItems(Rarity.ItemDB.pets, twwPets)

--- a/Locales.lua
+++ b/Locales.lua
@@ -2,6 +2,11 @@ local L
 L = LibStub("AceLocale-3.0"):NewLocale("Rarity", "enUS", true)
 
 -- L["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] = true
+L["Sneef"] = true
+L["Violet Sporbit"] = true
+L["Chester"] = true
+L["Wriggle"] = true
+L["Bouncer"] = true
 L["Writhing Transmutagen"] = true
 L["When enabled, Rarity will not add tooltip information for items that aren't being tracked."] = true
 L["Hide untracked items in tooltips"] = true


### PR DESCRIPTION
Resolves #767.

---

Incomplete: Need to add the detection, which relies on UI Map IDs - but there's duplicates. And someone needs to test (ingame).