### PR TITLE
Update the TOC versioning scheme to make sure it's recognized as compatible

### DIFF
--- a/.github/check-interface-versions.sh
+++ b/.github/check-interface-versions.sh
@@ -1,19 +1,19 @@
-local_version=$(cat Rarity.toc | grep -oP '## Interface: \K\d+')
-options_version=$(cat Modules/Options/Rarity_Options.toc | grep -oP '## Interface: \K\d+')
+local_version=$(cat Rarity.toc | grep -oP '## Interface: \K(\d{6},? ?)+')
+options_version=$(cat Modules/Options/Rarity_Options.toc | grep -oP '## Interface: \K(\d{6},? ?)+')
 
 # Since there's no "official" way to get the latest version, just use a popular/frequently updated addon ...
-remote_version=$(curl https://raw.githubusercontent.com/BigWigsMods/BigWigs/master/BigWigs.toc --silent | grep -oP '## Interface:.*' | grep -oP '\d+' | sort -nr | head -n 1)
+remote_version=$(curl https://raw.githubusercontent.com/BigWigsMods/BigWigs/master/BigWigs.toc --silent | grep -oP '## Interface: \K(\d{6},? ?)+')
 
 if [ "$local_version" != "$remote_version" ]; then
-    echo "Local interface version ($local_version) is not up to date with remote version ($remote_version)"
+    echo "✗ Local interface version ($local_version) does NOT match remote version ($remote_version)"
     exit 1
 else
-    echo "Local interface version ($local_version) is up to date with remote version ($remote_version)"
+    echo "✓ Local interface version ($local_version) matches remote version ($remote_version)"
 fi
 
 if [ "$local_version" != "$options_version" ]; then
-    echo "Core interface version ($local_version) is NOT identical to the options version ($options_version)"
+    echo "✗ Core interface version ($local_version) does NOT match options version ($options_version)"
     exit 1
 else
-    echo "Core interface version ($local_version) is identical to the options version ($options_version)"
+    echo "✓ Core interface version ($local_version) matches options version ($options_version)"
 fi

--- a/Modules/Options/Rarity_Options.toc
+++ b/Modules/Options/Rarity_Options.toc
@@ -1,5 +1,5 @@
 ## Author: Allara
-## Interface: 110005
+## Interface: 110005, 110000, 110002
 ## X-Min-Interface: 110005
 ## Notes: Rarity configuration. Use AddonLoader to load this on demand.
 ## Title: Rarity [|caaedc99fOptions|r]

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -1,5 +1,5 @@
 ## Author: Allara
-## Interface: 110005
+## Interface: 110005, 110000, 110002
 ## X-Min-Interface: 110005
 ## Title: Rarity
 ## Version: 1.0 (@project-version@)


### PR DESCRIPTION
It's become evident that neither the WOW client not Curse are able to infer live compatibility from the PTR version. 