### PR TITLE
Exclude test files from published releases

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -86,6 +86,7 @@ move-folders:
     Rarity/Modules/Options: Rarity_Options
 
 ignore:
+ - Tests
  - README.MD
  - Changes.lua
  - .luacheckrc


### PR DESCRIPTION
That's clearly an oversight. What would players even do with them?