### PR TITLE
Remove the redundant .pkgmeta ignore list entry for .luacheckrc

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -89,5 +89,4 @@ ignore:
  - Tests
  - README.MD
  - Changes.lua
- - .luacheckrc
  - autoformat.sh


### PR DESCRIPTION
Dot files are always ignored by the packager and needn't be listed.

---

From the [CurseForge docs](https://support.curseforge.com/en/support/solutions/articles/9000197952-preparing-the-packagemeta-file#Ignoring-folders-or-files):

> Files beginning with a period, like .pkgmeta and .docmeta, are always ignored by the packager and should not be listed here.