### PR TITLE
Fixing wrong syntax for utility function FormatTime

### DIFF
--- a/Utils/PrettyPrint.lua
+++ b/Utils/PrettyPrint.lua
@@ -46,7 +46,7 @@ end
 
 --- Prints timestamps in a human-readable fashion?
 -- TODO: LuaDoc
-function PP:FormatTime(t)
+function PP.FormatTime(t)
 	if not t then
 		return "0:00"
 	end


### PR DESCRIPTION
With `PP:FormatTime` all times were being returned as "0:00" since the "self" argument was missing, and all times would appear as `nil` for the `t` argument, causing the 

```lua
if not t then
    return "0:00"
end
``` 
code to always run.

Particularly, this fixes the empty "Time" column in the main display.

![image](https://github.com/user-attachments/assets/ea2fe6eb-e928-4cc0-8ffc-456377641ad8)
