### PR TITLE
Pin the unit test workflow to ubuntu-22.04

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   build:
     name: Run unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Download test runner
         uses: evo-lua/evo-setup-action@main
         with:
-          version: 'v0.0.9'
+          version: 'v0.0.20'
 
       - name: Run unit tests
         run: evo Tests/unit-test.lua


### PR DESCRIPTION
GitHub updated the `ubuntu-latest` tag so that it now points to `ubuntu-24.04`. There's no release of the Lua runtime that's built using the updated system libraries yet (nor is it needed here). This should fix the CI failures at least.