### PR TITLE
Removed RegisterEvent calls for the now-unused legacy player interaction events

### DIFF
--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -63,12 +63,6 @@ function EventHandlers:Register()
 	self:RegisterEvent("CURRENCY_DISPLAY_UPDATE", "OnCurrencyUpdate")
 	self:RegisterEvent("RESEARCH_ARTIFACT_COMPLETE", "OnResearchArtifactComplete")
 	self:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED", "OnCombat") -- Used to detect boss kills that we didn't solo
-	self:RegisterEvent("BANKFRAME_OPENED", "OnEvent")
-	self:RegisterEvent("BANKFRAME_CLOSED", "OnEvent")
-	self:RegisterEvent("GUILDBANKFRAME_OPENED", "OnEvent")
-	self:RegisterEvent("GUILDBANKFRAME_CLOSED", "OnEvent")
-	self:RegisterEvent("MAIL_CLOSED", "OnEvent")
-	self:RegisterEvent("MAIL_SHOW", "OnEvent")
 	self:RegisterEvent("CURSOR_CHANGED", "OnCursorChanged") -- Fishing detection
 	self:RegisterEvent("UNIT_SPELLCAST_SENT", "OnSpellcastSent") -- Fishing detection
 	self:RegisterEvent("UNIT_SPELLCAST_STOP", "OnSpellcastStopped") -- Fishing detection
@@ -76,10 +70,6 @@ function EventHandlers:Register()
 	self:RegisterEvent("UNIT_SPELLCAST_INTERRUPTED", "OnSpellcastFailed") -- Fishing detection
 	self:RegisterEvent("LOOT_CLOSED", "OnLootFrameClosed") -- Fishing detection
 	self:RegisterEvent("PLAYER_LOGOUT", "OnEvent")
-	self:RegisterEvent("AUCTION_HOUSE_CLOSED", "OnEvent")
-	self:RegisterEvent("AUCTION_HOUSE_SHOW", "OnEvent")
-	self:RegisterEvent("TRADE_CLOSED", "OnEvent")
-	self:RegisterEvent("TRADE_SHOW", "OnEvent")
 	self:RegisterEvent("TRADE_SKILL_SHOW", "OnEvent")
 	self:RegisterEvent("TRADE_SKILL_CLOSE", "OnEvent")
 	self:RegisterEvent("UPDATE_MOUSEOVER_UNIT", "OnMouseOver")


### PR DESCRIPTION
Forgot to remove those earlier. With PLAYER_INTERACTION_MANAGER_FRAME_SHOW and PLAYER_INTERACTION_MANAGER_FRAME_HIDE, there's no need for them any more.