### PR TITLE
Upgrade the CDN version check (and related tools) to support multiple TOC interface versions

### DIFF
--- a/.github/check-interface-versions.sh
+++ b/.github/check-interface-versions.sh
@@ -1,4 +1,6 @@
 set -eu
 
-curl --silent --show-error https://us.version.battle.net/v2/products/wow/versions > cdn-response.txt
-evo Tools/check-cdn-version.lua cdn-response.txt
+curl --silent --show-error https://us.version.battle.net/v2/products/wow/versions > retail-mainline-versions.txt
+curl --silent --show-error https://us.version.battle.net/v2/products/wow_classic/versions > cata-classic-versions.txt
+curl --silent --show-error https://us.version.battle.net/v2/products/wow_classic_era/versions > classic-era-versions.txt
+evo Tools/check-cdn-version.lua retail-mainline-versions.txt cata-classic-versions.txt classic-era-versions.txt

--- a/Modules/Options/Rarity_Options.toc
+++ b/Modules/Options/Rarity_Options.toc
@@ -1,6 +1,6 @@
 ## Author: Allara
-## Interface: 110007
-## X-Min-Interface: 110007
+## Interface: 110100, 40402, 11506
+## X-Min-Interface: 110100, 40402, 11506
 ## Notes: Rarity configuration. Should be loaded automatically on demand.
 ## Title: Rarity [|caaedc99fOptions|r]
 ## Dependencies: Rarity

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -1,6 +1,6 @@
 ## Author: Allara
-## Interface: 110007
-## X-Min-Interface: 110007
+## Interface: 110100, 40402, 11506
+## X-Min-Interface: 110100, 40402, 11506
 ## Title: Rarity
 ## Version: 1.0 (@project-version@)
 ## X-Curse-Project-ID: 30801

--- a/Tests/Fixtures/Test.toc
+++ b/Tests/Fixtures/Test.toc
@@ -1,0 +1,5 @@
+## Author: Anonymous
+## Interface: 12345
+## X-Min-Interface: 12345
+## Title: AddonName
+## Version: 0.1 (@project-version@)

--- a/Tests/TOC/BlizzardTOC.lua
+++ b/Tests/TOC/BlizzardTOC.lua
@@ -8,12 +8,24 @@ function BlizzardTOC:DecodeFileContents(fileContents)
 		line = line:gsub("\r", "") -- Avoids crossplatform headaches (autoformat doesn't modify TOC files)
 		toc["Title"] = toc["Title"] or line:match("^## Title: (.+)")
 		toc["Author"] = toc["Author"] or line:match("^## Author: (.+)")
-		toc["Interface"] = toc["Interface"] or tonumber(line:match("^## Interface: (%d+)"))
-		toc["X-Min-Interface"] = toc["X-Min-Interface"] or tonumber(line:match("^## X%-Min%-Interface: (%d+)"))
+		toc["Interface"] = toc["Interface"] or line:match("^## Interface: ([%d,%s]+)")
+		toc["X-Min-Interface"] = toc["X-Min-Interface"] or line:match("^## X%-Min%-Interface: ([%d,%s]+)")
 		toc["X-Curse-Project-ID"] = toc["X-Curse-Project-ID"]
 			or tonumber(line:match("^## X%-Curse%-Project%-ID: (%d+)"))
 		toc["Dependencies"] = toc["Dependencies"] or line:match("^## Dependencies: (.+)")
 		toc["X-Part-Of"] = toc["X-Part-Of"] or line:match("^## X%-%Part%-Of: (.+)")
+	end
+
+	toc["Interface"] = toc["Interface"]:gsub(",", "")
+	toc["Interface"] = string.explode(toc["Interface"], " ")
+	for index, version in ipairs(toc["Interface"]) do
+		toc["Interface"][index] = tonumber(version)
+	end
+
+	toc["X-Min-Interface"] = toc["X-Min-Interface"]:gsub(",", "")
+	toc["X-Min-Interface"] = string.explode(toc["X-Min-Interface"], " ")
+	for index, version in ipairs(toc["X-Min-Interface"]) do
+		toc["X-Min-Interface"][index] = tonumber(version)
 	end
 
 	return toc

--- a/Tests/TOC/CDN.lua
+++ b/Tests/TOC/CDN.lua
@@ -41,6 +41,7 @@ local function parseNextLine(response, line)
 		return
 	end
 
+	line = line:gsub("||", "|nil|") -- It's not stupid if it works :3
 	local tokens = string_explode(line, "|")
 
 	-- Parse header (first line)

--- a/Tests/test-toc.spec.lua
+++ b/Tests/test-toc.spec.lua
@@ -1,11 +1,15 @@
 local BlizzardTOC = require("Tests.TOC.BlizzardTOC")
 local CDN = require("Tests.TOC.CDN")
 
+local uv = require("uv")
+
 local VALID_RESPONSE_FILE = path.join("Tests", "Fixtures", "cdn-response-example.txt")
 local VALID_RESPONSE_TEXT = C_FileSystem.ReadFile(VALID_RESPONSE_FILE)
 local INVALID_RESPONSE_FILE = path.join("Tests", "Fixtures", "cdn-response-malformed-header.txt")
 local INVALID_RESPONSE_TEXT = C_FileSystem.ReadFile(INVALID_RESPONSE_FILE)
 
+local EXAMPLE_TOC_PATH = path.join(uv.cwd(), "Tests", "Fixtures", "Test.toc")
+local EXAMPLE_TOC_FILE = C_FileSystem.ReadFile(EXAMPLE_TOC_PATH)
 local RARITY_CORE_TOC = C_FileSystem.ReadFile("Rarity.toc")
 local RARITY_OPTIONS_TOC = C_FileSystem.ReadFile(path.join("Modules", "Options", "Rarity_Options.toc"))
 
@@ -19,20 +23,31 @@ local EXAMPLE_PRODUCT_INFO = {
 	VersionsName = "11.0.5.57212",
 }
 
+local NUM_SUPPORTED_PRODUCT_LINES = 3
+
 describe("TOC", function()
 	describe("BlizzardTOC", function()
 		describe("DecodeFileContents", function()
-			it("should be able to load valid TOC files", function()
+			it("should be able to load valid TOC files using a single interface version", function()
+				local toc = BlizzardTOC:DecodeFileContents(EXAMPLE_TOC_FILE)
+				assertEquals(toc["Title"], "AddonName")
+				assertEquals(toc["Author"], "Anonymous")
+				assertEquals(toc["Interface"], { 12345 })
+			end)
+
+			it("should be able to load valid TOC files using multiple interface versions", function()
 				local RarityCoreTOC = BlizzardTOC:DecodeFileContents(RARITY_CORE_TOC)
 				local RarityOptionsTOC = BlizzardTOC:DecodeFileContents(RARITY_OPTIONS_TOC)
 
 				-- For now, only parse the header (other fields can be added as needed)
 				assertEquals(RarityCoreTOC["Title"], "Rarity")
 				assertEquals(RarityCoreTOC["Author"], "Allara")
-				assertTrue(RarityCoreTOC["Interface"] > 0)
-				assertEquals(type(RarityCoreTOC["X-Min-Interface"]), "number")
 				assertEquals(RarityCoreTOC["X-Curse-Project-ID"], 30801)
-				assertEquals(RarityCoreTOC["Interface"], RarityCoreTOC["X-Min-Interface"])
+				assertTrue(#RarityCoreTOC["Interface"] == NUM_SUPPORTED_PRODUCT_LINES)
+				assertTrue(#RarityCoreTOC["X-Min-Interface"] == NUM_SUPPORTED_PRODUCT_LINES)
+				assertEquals(RarityCoreTOC["Interface"][1], RarityCoreTOC["X-Min-Interface"][1])
+				assertEquals(RarityCoreTOC["Interface"][2], RarityCoreTOC["X-Min-Interface"][2])
+				assertEquals(RarityCoreTOC["Interface"][3], RarityCoreTOC["X-Min-Interface"][3])
 
 				assertEquals(RarityOptionsTOC["Title"], "Rarity [|caaedc99fOptions|r]")
 				assertEquals(RarityOptionsTOC["Dependencies"], "Rarity")

--- a/Tools/check-cdn-version.lua
+++ b/Tools/check-cdn-version.lua
@@ -4,24 +4,35 @@ local CDN = require("Tests.TOC.CDN")
 local transform = require("transform")
 local bold = transform.bold
 
-local cdnResponseText = C_FileSystem.ReadFile(arg[1])
-C_FileSystem.Delete(arg[1])
-local coreAddonVersion = arg[2]
-local optionsAddonVersion = arg[3]
+local cdnResponseTexts = {
+	C_FileSystem.ReadFile(arg[1]),
+	C_FileSystem.ReadFile(arg[2]),
+	C_FileSystem.ReadFile(arg[3]),
+}
 
-printf("Parsing CDN response:\n%s", transform.cyan(cdnResponseText))
-local response = CDN:ParseResponseText(cdnResponseText)
-printf(transform.yellow("Sequence number: %d"), response.sequenceNumber)
-printf(transform.yellow("Region keys: %s"), dump(table.keys(response.productInfoByRegion), { silent = true }))
+assert(C_FileSystem.Delete(arg[1]))
+assert(C_FileSystem.Delete(arg[2]))
+assert(C_FileSystem.Delete(arg[3]))
 
-print()
+local cdnResponses = {}
 
-for regionKey, productInfo in pairs(response.productInfoByRegion) do
-	if regionKey == "us" then
-		for key, value in pairs(productInfo) do
-			printf(bold("%s") .. ": %s", key, value)
+for index, cdnResponseText in ipairs(cdnResponseTexts) do
+	printf("Parsing CDN response:\n%s", transform.cyan(cdnResponseText))
+	local response = CDN:ParseResponseText(cdnResponseText)
+	printf(transform.yellow("Sequence number: %d"), response.sequenceNumber)
+	printf(transform.yellow("Region keys: %s"), dump(table.keys(response.productInfoByRegion), { silent = true }))
+
+	print()
+
+	for regionKey, productInfo in pairs(response.productInfoByRegion) do
+		if regionKey == "us" then
+			for key, value in pairs(productInfo) do
+				printf(bold("%s") .. ": %s", key, value)
+			end
 		end
 	end
+
+	table.insert(cdnResponses, response)
 end
 
 print()
@@ -35,27 +46,30 @@ for moduleName, tocFilePath in pairs(tocFiles) do
 	local tocFileContents = C_FileSystem.ReadFile(tocFilePath)
 	printf("Processing TOC file: %s -> %s", bold(moduleName), bold(tocFilePath))
 	local toc = BlizzardTOC:DecodeFileContents(tocFileContents)
+	assert(#toc["Interface"] == #cdnResponses, "Expected one TOC version per supported product line")
 
-	local tocInterfaceVersion = toc["Interface"]
-	printf(bold("Detected interface version: %d"), tocInterfaceVersion)
+	for index, response in ipairs(cdnResponses) do
+		local tocInterfaceVersion = toc["Interface"][index]
+		printf(bold("Detected interface version: %s"), tocInterfaceVersion)
 
-	-- Assumes the US CDN is authoritative (should be the earliest to update?)
-	local usVersionName = response.productInfoByRegion.us.VersionsName
-	local latestInterfaceVersion = CDN:VersionNameToInterfaceVersion(usVersionName)
+		-- Assumes the US CDN is authoritative (should be the earliest to update?)
+		local usVersionName = response.productInfoByRegion.us.VersionsName
+		local latestInterfaceVersion = assert(CDN:VersionNameToInterfaceVersion(usVersionName))
 
-	if tocInterfaceVersion ~= latestInterfaceVersion then
-		local errorMessage = format(
-			"✗ Local TOC interface version %d does NOT match Blizzard CDN version %d",
-			tocInterfaceVersion,
-			latestInterfaceVersion
-		)
-		error(transform.red(errorMessage))
-	else
-		printf(
-			transform.green("✓ Local TOC interface version %d matches Blizzard CDN version %d"),
-			tocInterfaceVersion,
-			latestInterfaceVersion
-		)
+		if tocInterfaceVersion ~= latestInterfaceVersion then
+			local errorMessage = format(
+				"✗ Local TOC interface version %d does NOT match Blizzard CDN version %d",
+				tocInterfaceVersion,
+				latestInterfaceVersion
+			)
+			error(transform.red(errorMessage))
+		else
+			printf(
+				transform.green("✓ Local TOC interface version %d matches Blizzard CDN version %d"),
+				tocInterfaceVersion,
+				latestInterfaceVersion
+			)
+		end
+		print()
 	end
-	print()
 end


### PR DESCRIPTION
With this, it should be possible to manage all three WOW product lines (Retail, Cata, Classic Era) with just one TOC file.

(Technically this flags the addon as compatible with classic clients even if the necessary changes aren't merged yet)