### PR TITLE
Remove GetDistanceToItem and Libs/HereBeDragons-2.0

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -68,9 +68,6 @@ externals:
     Libs/LibBabble-Boss-3.0:
         url: https://repos.wowace.com/wow/libbabble-boss-3-0/trunk
         tag: latest
-    Libs/HereBeDragons-2.0:
-        url: git://git.wowace.com/wow/herebedragons/mainline.git
-        tag: latest
     Libs/LibCompress:
         url: https://repos.wowace.com/wow/libcompress/trunk
         tag: latest

--- a/Core.lua
+++ b/Core.lua
@@ -5,7 +5,6 @@ local R = Rarity
 local lbz = LibStub("LibBabble-Zone-3.0"):GetUnstrictLookupTable()
 local lbsz = LibStub("LibBabble-SubZone-3.0"):GetUnstrictLookupTable()
 local lbb = LibStub("LibBabble-Boss-3.0"):GetUnstrictLookupTable()
-local hbd = LibStub("HereBeDragons-2.0")
 
 ---
 
@@ -441,34 +440,6 @@ function R:tcopy(to, from)
 			to[k] = v
 		end
 	end
-end
-
--- Location/Distance/Zone
-function R:GetDistanceToItem(item)
-	local distance = 999999999
-	if item and type(item) == "table" and item.coords and type(item.coords) == "table" then
-		local playerWorldX, playerWorldY, instance = hbd:GetPlayerWorldPosition()
-		for k, v in pairs(item.coords) do
-			if v and type(v) == "table" and v.m and v.i ~= true then
-				local map = v.m
-				local x = (v.x or 50) / 100
-				local y = (v.y or 50) / 100
-				local itemWorldX, itemWorldY = hbd:GetWorldCoordinatesFromZone(x, y, map, v.f or 1)
-				if itemWorldX ~= nil then -- Library returns nil for instances
-					local thisDistance =
-						hbd:GetWorldDistance(instance, itemWorldX, itemWorldY, playerWorldX, playerWorldY)
-					-- R:Print("map: "..map..", x: "..x..", y: "..y..", itemWorldX: "..itemWorldX..", itemWorldY: "..itemWorldY..", playerWorldX: "..playerWorldX..", playerWorldY: "..playerWorldY..", thisDistance: "..thisDistance)
-					if thisDistance < distance then
-						distance = thisDistance
-					end
-				end
-			end
-		end
-	end
-	if distance ~= 999999999 then
-		return distance
-	end
-	return nil
 end
 
 -- Prepares a set of lookup tables to let us quickly determine if we're interested in various things.

--- a/Rarity.toc
+++ b/Rarity.toc
@@ -22,7 +22,7 @@
 ## AddonCompartmentFuncOnLeave: Rarity_OnAddonCompartmentLeave
 ## IconTexture: Interface\Icons\spell_nature_forceofnature.blp
 
-## OptionalDeps: Ace3,LibDualSpec-1.0,LibQTip-1.0,LibDBIcon-1.0,LibBabble-Zone-3.0,LibSink-2.0,LibBabble-SubZone-3.0,LibSharedMedia-3.0,AceGUI-3.0-SharedMediaWidgets,LibBabble-CreatureType-3.0,LibBabble-Boss-3.0,HereBeDragons
+## OptionalDeps: Ace3,LibDualSpec-1.0,LibQTip-1.0,LibDBIcon-1.0,LibBabble-Zone-3.0,LibSink-2.0,LibBabble-SubZone-3.0,LibSharedMedia-3.0,AceGUI-3.0-SharedMediaWidgets,LibBabble-CreatureType-3.0,LibBabble-Boss-3.0
 ## SavedVariables: RarityDB
 ## X-LoadOn-Always: delayed
 #@no-lib-strip@
@@ -49,7 +49,6 @@ Libs\LibSharedMedia-3.0\lib.xml
 Libs\AceGUI-3.0-SharedMediaWidgets\widget.xml
 Libs\LibBabble-CreatureType-3.0\lib.xml
 Libs\LibBabble-Boss-3.0\lib.xml
-Libs\HereBeDragons-2.0\HereBeDragons-2.0.lua
 Libs\LibCompress\lib.xml
 #@end-no-lib-strip@
 Libs\LibBars-1.0\lib.xml


### PR DESCRIPTION
This function hasn't been used, or even referenced, since at least 2018.

---

Before merging: Review SVN history to see why it was added (see https://en.wiktionary.org/wiki/Chesterton's_fence)

---

Tracing back the commits:

* `GetDistanceToItem` first appears in a9595831a9726a45f5103da711f317a4014b6da0 (introduces sorting by zone)
* The function isn't used by this sort method, which [still exists in the code](https://github.com/WowRarity/Rarity/blob/b097671102a599286ed7be613c627cd762cce4d6/Utils/Sorting.lua#L116-L151)
* There's apparently been no change to the implementation after that point
* Checking out the last SVN snapshot (f0aa6a7), there are 30 tags with this function included
* There's however not a single use, so it was probably an experiment (sort by proximity)

Given that the [referenced issue](https://www.wowace.com/projects/rarity/issues/156) doesn't mention it, I see no reason to keep this around.

---

Now, what about HereBeDragons?

* The first version was introduced in [r539-release](https://www.wowace.com/projects/rarity/files/931309) and later upgraded in 9b1a426b3ba0c61e7bb110c5fb9ea885819ae57f
* Commit 4c27d1dd562d729babf27aacbbf0f182836f4a0c introduces this dependency, but seems otherwise unrelated
* Its only use is in the above function, which was added long after HBD itself
* In fact, checking out the commit prior (3661dc8f8c35e9a23af092989086c371fe8bda3c) shows that `hbd` is unused

Seeing how the Map API has drastically changed and Rarity doesn't need HDB functions, it can also be removed.