### PR TITLE
Fix various script errors on Classic Era realms

### DIFF
--- a/Core/Collections.lua
+++ b/Core/Collections.lua
@@ -24,7 +24,9 @@ local C_PetJournal = C_PetJournal
 local GetNumCompanions = GetNumCompanions
 local GetCompanionInfo = GetCompanionInfo
 local GetAchievementInfo = GetAchievementInfo
-local GetNumArchaeologyRaces = GetNumArchaeologyRaces
+local GetNumArchaeologyRaces = GetNumArchaeologyRaces or function()
+	return 0
+end
 local GetNumArtifactsByRace = GetNumArtifactsByRace
 local GetArtifactInfoByRace = GetArtifactInfoByRace
 local IsQuestComplete = _G.C_QuestLog.IsComplete
@@ -53,6 +55,12 @@ function Collections:ScanTransmog(reason)
 end
 
 function Collections:ScanToys(reason)
+	if C_ToyBox.GetNumToys() == 0 then
+		-- Can't load Blizzard_Collections since it's broken in Classic Era
+		-- Toys are actually regular items here, so tracking should still work
+		return
+	end
+
 	self = Rarity
 	self:Debug("Scanning toys (" .. (reason or "") .. ")")
 
@@ -154,7 +162,7 @@ function Collections:ScanExistingItems(reason)
 	end
 
 	-- Companions that this character learned
-	for id = 1, GetNumCompanions("CRITTER") do
+	for id = 1, GetNumCompanions("CRITTER") or 0 do
 		local spellId = select(3, GetCompanionInfo("CRITTER", id))
 		for k, v in pairs(R.db.profile.groups) do
 			if type(v) == "table" then

--- a/Core/Detection.lua
+++ b/Core/Detection.lua
@@ -266,7 +266,7 @@ function R:ScanStatistics(reason)
 	table.wipe(Rarity.ach_npcs_isKilled)
 	table.wipe(Rarity.ach_npcs_achId)
 	for k, v in pairs(self.db.profile.achNpcs) do
-		local count = GetAchievementNumCriteria(v)
+		local count = GetAchievementNumCriteria(v) or 0
 		for i = 1, count do
 			local description, type, completed = GetAchievementCriteriaInfo(v, i)
 			Rarity.ach_npcs_achId[description] = v

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -42,7 +42,9 @@ local GetRealZoneText = _G.GetRealZoneText
 local GetContainerNumSlots = _G.C_Container.GetContainerNumSlots
 local GetContainerItemID = _G.C_Container.GetContainerItemID
 local GetContainerItemInfo = _G.C_Container.GetContainerItemInfo
-local GetNumArchaeologyRaces = _G.GetNumArchaeologyRaces
+local GetNumArchaeologyRaces = _G.GetNumArchaeologyRaces or function()
+	return 0
+end
 local GetArchaeologyRaceInfo = _G.GetArchaeologyRaceInfo
 local GetStatistic = _G.GetStatistic
 local GetLootSourceInfo = _G.GetLootSourceInfo

--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -375,7 +375,11 @@ local function onTooltipSetUnit(tooltip, data)
 	end
 end
 
-_G.TooltipDataProcessor.AddTooltipPostCall(_G.Enum.TooltipDataType.Unit, onTooltipSetUnit)
+if not _G.TooltipDataProcessor then
+	-- Blizzard hasn't ported the tooltip changes to their classic client, yet?
+else
+	_G.TooltipDataProcessor.AddTooltipPostCall(_G.Enum.TooltipDataType.Unit, onTooltipSetUnit)
+end
 
 local function processItem(id, tooltip)
 	local blankAdded = false
@@ -537,4 +541,8 @@ local function onTooltipSetItem(tooltip, tooltipData)
 	processItem(tonumber(id), tooltip)
 end
 
-_G.TooltipDataProcessor.AddTooltipPostCall(_G.Enum.TooltipDataType.Item, onTooltipSetItem)
+if not _G.TooltipDataProcessor then
+	-- Blizzard hasn't ported the tooltip changes to their classic client, yet?
+else
+	_G.TooltipDataProcessor.AddTooltipPostCall(_G.Enum.TooltipDataType.Item, onTooltipSetItem)
+end


### PR DESCRIPTION
The tooltip hooking functionality is going to be disabled, which isn't ideal. It should be possible to adapt the original retail code and make both methods work alongside each other. Since I don't have time to look into that right now and it's probably not a critical issue (at least for the next release), I'll leave it for later. Classic Era likely needs more work in general.