### PR TITLE
Migrate Crashin' Thrashin' Battleship attempts on load

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -328,6 +328,7 @@ do
 		if self.db.profile.verifyDatabaseOnLogin then
 			self.Validation:ValidateItemDB()
 		end
+		self.Database:ApplyMigrations()
 	end
 end
 


### PR DESCRIPTION
This item had a typo in its name (extra parenthesis). While splitting the holiday events database, the typo was fixed. Unfortunately that means anyone who had attempts recorded under the old name would suddenly find them missing.

The easy way around this would be to just restore the old name and leave it unchanged, forever. But there are some other items that would benefit from a migration system: Firstly, the "Big Love Rocket" is no longer named that, and then there's the manual "purge" command for Island Expedition items that never made it to live. Whether this approach is right, I've no idea.

The migration logic is extremely basic so as to avoid destroying any data. Keeping in mind there are no tests for this yet, it does seem like the safest route. Eventually there may be tests and then this functionality can be extended. For now, I'd rather not mess with the DB internals any more than necessary, especially because many people don't seem to create any backups.
