### PR TITLE
Explicitly set ChatFrame as the default output sink

### DIFF
--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -99,6 +99,11 @@ function R:PrepareDefaults()
 			blankLineAfterRarity = false,
 			hideOutsideZone = false,
 			showAchievementToast = true,
+
+			-- Since 10.0 the default channel used by LibSink is Blizzard's Floating Combat Text
+			-- This isn't what people have come to expect of Rarity, so let's just change it back
+			sink20OutputSink = "ChatFrame",
+
 			tooltipShowDelay = 0.1,
 
 			trackedGroup = "pets",


### PR DESCRIPTION
This used to be the standard option in LibSink, but since Blizzard's UI revamp in 10.0, LibSink falls back to the floating combat text instead. There have been numerous reports of people not liking this change, or in some cases even being unable to see announcements at all. They will usually blame Rarity and/or be confused by the lack of selected output channels.

---

Resolves #820 .