### PR TITLE
Remove the addon-loader entry from .pkgmeta

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -80,7 +80,6 @@ externals:
 
 tools-used:
     - libdatabroker-1-1
-    - addon-loader
 
 move-folders:
     Rarity/Modules/Options: Rarity_Options


### PR DESCRIPTION
Support for the obsolete and unmaintained AddonLoader tool was dropped in favor of Blizzard's equivalent system (see #752). WowAce still lists it as a dependency because this entry wasn't removed, though.