### PR TITLE
Restore the original name for Crashin' Thrashin' Battleship

### DIFF
--- a/DB/Toys/HolidayEvents_BattleForAzeroth.lua
+++ b/DB/Toys/HolidayEvents_BattleForAzeroth.lua
@@ -8,7 +8,7 @@ if LE_EXPANSION_LEVEL_CURRENT < LE_EXPANSION_BATTLE_FOR_AZEROTH then
 end
 
 local holidayEventToysBfA = {
-	["Crashin' Thrashin' Battleship"] = {
+	["Crashin' Thrashin' Battleship)"] = { --Do not fix this typo until attempts can safely be migrated (see #824)
 		cat = CONSTANTS.ITEM_CATEGORIES.HOLIDAY,
 		type = CONSTANTS.ITEM_TYPES.ITEM,
 		isToy = true,


### PR DESCRIPTION
This typo was fixed when splitting the holiday items database (in b2b1f3063e27160ac8114bde6dc55b2d50532b30), but previous attempts would have been stored under the old (incorrect) name. I don't have time to refine the WIP migration PR (#824) before the next release, so it's probably better to restore the original name for the time being, and take all the time needed to fix the database up properly later.

Players will only see the localized name, which doesn't contain the typo. Fixing the name is of moderate utility at best and can be deferred. I'd rather not merge a half-baked DB migration feature before I've spent more time on refining and testing it.