### PR TITLE
Enable deferred loading of the Options module

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -111,6 +111,9 @@ local IsSpellKnown = _G.IsSpellKnown
 local CombatLogGetCurrentEventInfo = _G.CombatLogGetCurrentEventInfo
 local IsQuestFlaggedCompleted = _G.C_QuestLog.IsQuestFlaggedCompleted
 local C_Covenants = _G.C_Covenants
+local EnableAddOn = C_AddOns.EnableAddOn
+local IsAddOnLoadable = C_AddOns.IsAddOnLoadable
+local IsAddOnLoaded = C_AddOns.IsAddOnLoaded
 local LoadAddOn = _G.C_AddOns.LoadAddOn
 
 local COMBATLOG_OBJECT_AFFILIATION_MINE = _G.COMBATLOG_OBJECT_AFFILIATION_MINE
@@ -347,6 +350,22 @@ do
 	end
 end
 
+local fallbackOptionsTable = {
+	type = "group",
+	name = L["Rarity"],
+	width = "full",
+	args = {
+		enable = {
+			name = L["Attempt to enable the Options module"],
+			type = "execute",
+			width = "full",
+			func = function(info, val)
+				EnableAddOn("Rarity_Options")
+			end,
+		},
+	},
+}
+
 function Rarity:LazyLoadOptions(which)
 	local options = R[which]
 	if type(options) == "table" then
@@ -355,21 +374,27 @@ function Rarity:LazyLoadOptions(which)
 	end
 
 	Rarity.Profiling:StartTimer("RarityOptions: LoadAddon")
-	LoadAddOn("Rarity_Options")
+	local didLoad, errorMessage = LoadAddOn("Rarity_Options")
+	if not didLoad then
+		Rarity:Debug("Options failed to load? Reason: " .. errorMessage or "nil")
+		return fallbackOptionsTable
+	end
 	Rarity.Profiling:EndTimer("RarityOptions: LoadAddon")
 
 	return R[which]
 end
 
 function Rarity:TryShowOptionsUI()
-	Rarity:LazyLoadOptions()
-	if R.options then
-		Rarity.Profiling:StartTimer("RarityOptions: OpenToCategory")
-		Settings.OpenToCategory("Rarity")
-		Rarity.Profiling:EndTimer("RarityOptions: OpenToCategory")
-	else
+	local canLoadOptions, reason = IsAddOnLoadable("Rarity_Options")
+	if not canLoadOptions and reason == "DISABLED" then
 		self:Print(L["The Rarity Options module has been disabled. Log out and enable it from your add-ons menu."])
+		return
 	end
+
+	Rarity:LazyLoadOptions()
+	Rarity.Profiling:StartTimer("RarityOptions: OpenToCategory")
+	Settings.OpenToCategory("Rarity")
+	Rarity.Profiling:EndTimer("RarityOptions: OpenToCategory")
 end
 
 function R:DelayedInit()

--- a/Core.lua
+++ b/Core.lua
@@ -361,6 +361,17 @@ function Rarity:LazyLoadOptions(which)
 	return R[which]
 end
 
+function Rarity:TryShowOptionsUI()
+	Rarity:LazyLoadOptions()
+	if R.options then
+		Rarity.Profiling:StartTimer("RarityOptions: OpenToCategory")
+		Settings.OpenToCategory("Rarity")
+		Rarity.Profiling:EndTimer("RarityOptions: OpenToCategory")
+	else
+		self:Print(L["The Rarity Options module has been disabled. Log out and enable it from your add-ons menu."])
+	end
+end
+
 function R:DelayedInit()
 	self:ScanStatistics("DELAYED INIT")
 	self:ScanCalendar("DELAYED INIT")

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -744,14 +744,7 @@ function R:OnChatCommand(input)
 	elseif strlower(input) == "tinspect" then --  TODO Document it?
 		Rarity.Profiling:InspectAccumulatedTimes()
 	else
-		Rarity:LazyLoadOptions()
-		if R.options then
-			Rarity.Profiling:StartTimer("RarityOptions: OpenToCategory")
-			Settings.OpenToCategory("Rarity")
-			Rarity.Profiling:EndTimer("RarityOptions: OpenToCategory")
-		else
-			self:Print(L["The Rarity Options module has been disabled. Log out and enable it from your add-ons menu."])
-		end
+		Rarity:TryShowOptionsUI()
 	end
 end
 

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -744,9 +744,11 @@ function R:OnChatCommand(input)
 	elseif strlower(input) == "tinspect" then --  TODO Document it?
 		Rarity.Profiling:InspectAccumulatedTimes()
 	else
-		LoadAddOn("Rarity_Options")
-		if R.optionsFrame then
+		Rarity:LazyLoadOptions()
+		if R.options then
+			Rarity.Profiling:StartTimer("RarityOptions: OpenToCategory")
 			Settings.OpenToCategory("Rarity")
+			Rarity.Profiling:EndTimer("RarityOptions: OpenToCategory")
 		else
 			self:Print(L["The Rarity Options module has been disabled. Log out and enable it from your add-ons menu."])
 		end

--- a/Core/GUI/DataBrokerDisplay.lua
+++ b/Core/GUI/DataBrokerDisplay.lua
@@ -60,14 +60,7 @@ function dataobj:OnClick(button)
 	local isLeftButton = button == "LeftButton"
 
 	if IsShiftKeyDown() and isLeftButton then
-		-- Show options
-		Rarity:Debug("Loading Rarity_Options addon")
-		LoadAddOn("Rarity_Options")
-		if R.optionsFrame then
-			Settings.OpenToCategory("Rarity")
-		else
-			R:Print(L["The Rarity Options module has been disabled. Log out and enable it from your add-ons menu."])
-		end
+		Rarity:TryShowOptionsUI()
 	elseif IsControlKeyDown() and isLeftButton then
 		Rarity.GUI:SelectNextSortOrder()
 	elseif

--- a/Core/Interoperability/Blizzard/AddonCompartment.lua
+++ b/Core/Interoperability/Blizzard/AddonCompartment.lua
@@ -6,13 +6,7 @@ local LoadAddOn = _G.C_AddOns.LoadAddOn
 local AddonCompartment = {}
 
 function AddonCompartment.OnClick()
-	-- Should behave the same as the default /rarity slash command (copy/pasted for now) - improve UX later?
-	LoadAddOn("Rarity_Options")
-	if Rarity.optionsFrame then
-		Settings.OpenToCategory("Rarity")
-	else
-		Rarity:Print(L["The Rarity Options module has been disabled. Log out and enable it from your add-ons menu."])
-	end
+	Rarity:TryShowOptionsUI()
 end
 
 function AddonCompartment.OnEnter()

--- a/Locales.lua
+++ b/Locales.lua
@@ -2,6 +2,7 @@ local L
 L = LibStub("AceLocale-3.0"):NewLocale("Rarity", "enUS", true)
 
 -- L["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"] = true
+L["Attempt to enable the Options module"] = true
 L["Personalized Goblin S.C.R.A.Per"] = true
 L["Bronze Goblin Waveshredder"] = true
 L["Darkfuse Precipitant"] = true

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -117,16 +117,6 @@ do
 		R.modulesEnabled.options = true
 
 		R:PrepareOptions()
-
-		LibStub("AceConfig-3.0"):RegisterOptionsTable("Rarity", R.options)
-		R.optionsFrame = LibStub("AceConfigDialog-3.0"):AddToBlizOptions("Rarity", "Rarity")
-		R.profileOptions = LibStub("AceDBOptions-3.0"):GetOptionsTable(R.db)
-		LibStub("AceConfig-3.0"):RegisterOptionsTable("Rarity-Profiles", R.profileOptions)
-		R.profileFrame = LibStub("AceConfigDialog-3.0"):AddToBlizOptions("Rarity-Profiles", "Profiles", "Rarity")
-
-		LibStub("AceConfig-3.0"):RegisterOptionsTable("Rarity-Advanced", R.advancedSettings)
-		R.advancedSettingsFrame =
-			LibStub("AceConfigDialog-3.0"):AddToBlizOptions("Rarity-Advanced", "Advanced", "Rarity")
 	end
 end
 


### PR DESCRIPTION
With fallback in case they're disabled. There's no way this is 100% robust - there are too many failure states to manually test.
Either way, it should make it easier to see that the options are disabled and to load them directly inside the settings UI.

Also resolves #762 by registering the fallback UI + options tree in the core addon, lazy-loading the full UI as needed.