### PR TITLE
Fix early exit conditions for ItemRefTooltip hooks

### DIFF
--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -531,14 +531,13 @@ local function onTooltipSetItem(tooltip, tooltipData)
 		return
 	end
 
-	local itemLink = tooltipData.hyperlink
-	if type(itemLink) ~= "string" then
+	local itemID = tooltipData.id
+	if not itemID then
+		Rarity:Debug("Failed to set GameTooltip text (the provided data doesn't include an item ID)")
 		return
 	end
 
-	local id = itemLink:match("item:(%d+):")
-	assert(id, "Failed to extract item ID from item link (format might have changed?)")
-	processItem(tonumber(id), tooltip)
+	processItem(itemID, tooltip)
 end
 
 if not _G.TooltipDataProcessor then


### PR DESCRIPTION
The original code used item links, but that doesn't seem to be required with the new `TooltipDataProvider` system. AFAICT the handling now doesn't work at all for containers, since they don't provide a hyperlink property.

Maybe I've missed some API changes? Either way, this should work for containers in the inventory at least.

---

Resolves #746.