### PR TITLE
Skip ItemRefTooltip hooks when they're globally disabled

### DIFF
--- a/Core/GUI/GameTooltipHooks.lua
+++ b/Core/GUI/GameTooltipHooks.lua
@@ -527,6 +527,10 @@ local function processItem(id, tooltip)
 end
 
 local function onTooltipSetItem(tooltip, tooltipData)
+	if not R.db or R.db.profile.enableTooltipAdditions == false then
+		return
+	end
+
 	if tooltip ~= _G.GameTooltip and tooltip ~= _G.ItemRefTooltip then
 		return
 	end


### PR DESCRIPTION
There are two tooltip hooks, and `onTooltipSetUnit` checks for different conditions than `onTooltipSetItem`.
This setting therefore only hides the tooltip text for units, but not for container items.

---

Resolves #525.