### PR TITLE
Replace debugprofile calls with (mostly) equivalent Profiling API uses

### DIFF
--- a/Core/Collections.lua
+++ b/Core/Collections.lua
@@ -101,7 +101,7 @@ function Collections:ScanExistingItems(reason)
 	end
 
 	self:Debug("Scanning for existing items (" .. reason .. ")")
-	self:ProfileStart()
+	self.Profiling:StartTimer("Collections.ScanExistingItems")
 
 	-- Scans need to index by spellId, creatureId, achievementId, raceId, itemId (for toys), statisticId (which is a table; for stats)
 
@@ -281,28 +281,28 @@ function Collections:ScanExistingItems(reason)
 		end
 	end
 
-	self:ProfileStop("ScanExistingItems: Mounts/Pets/Achievements/Archaeology took %fms")
-
 	-- Other scans
+	self.Profiling:StartTimer("Collections.ScanStatistics")
 	self:ScanStatistics(reason)
-	self:ProfileStart2() -- Statistics does its own profiling
+	self.Profiling:EndTimer("Collections.ScanStatistics")
 
+	self.Profiling:StartTimer("Collections.ScanToys")
 	Rarity.Collections:ScanToys(reason)
-	self:ProfileStop2("Toys took %fms")
-	self:ProfileStart2()
+	self.Profiling:EndTimer("Collections.ScanToys")
 
+	self.Profiling:StartTimer("Collections.ScanTransmog")
 	Rarity.Collections:ScanTransmog(reason)
-	self:ProfileStop2("Transmog took %fms")
-	self:ProfileStart2()
+	self.Profiling:EndTimer("Collections.ScanTransmog")
 
+	self.Profiling:StartTimer("Collections.ScanCalendar")
 	self:ScanCalendar(reason)
-	self:ProfileStop2("Calendar took %fms")
-	self:ProfileStart2()
+	self.Profiling:EndTimer("Collections.ScanCalendar")
 
+	self.Profiling:StartTimer("Collections.ScanInstanceLocks")
 	self:ScanInstanceLocks(reason)
-	self:ProfileStop2("Instances took %fms")
+	self.Profiling:EndTimer("Collections.ScanInstanceLocks")
 
-	self:ProfileStop("ScanExistingItems: Total time %fms")
+	self.Profiling:EndTimer("Collections.ScanExistingItems")
 end
 
 -------------------------------------------------------------------------------------

--- a/Core/Debugging.lua
+++ b/Core/Debugging.lua
@@ -17,8 +17,8 @@ function R:Debug(s, ...)
 	DebugCache:AddMessage(format(s, ...))
 end
 
-	if self.db.profile.enableProfiling then
 function R:ProfileDebug(s)
+	if self.db.profile.enableProfiling and self.db.profile.debugMode then
 		R:Print(s)
 	end
 end

--- a/Core/Debugging.lua
+++ b/Core/Debugging.lua
@@ -9,9 +9,6 @@ local DebugCache = Rarity.Utils.DebugCache
 -- Lua APIs
 local format = format
 
--- WOW APIs
-local debugprofilestop = debugprofilestop
-
 -- Debug mode and profiling
 function R:Debug(s, ...)
 	if self.db.profile.debugMode then
@@ -20,36 +17,8 @@ function R:Debug(s, ...)
 	DebugCache:AddMessage(format(s, ...))
 end
 
-local start1, stop1, start2, stop2
-
-function R:ProfileStart()
 	if self.db.profile.enableProfiling then
-		start1 = debugprofilestop()
-	end
-end
-
-function R:ProfileStart2()
-	if self.db.profile.enableProfiling then
-		start2 = debugprofilestop()
-	end
-end
-
-function R:ProfileStop(s)
-	if self.db.profile.enableProfiling then
-		stop1 = debugprofilestop()
-		R:Print(format(s, stop1 - start1))
-	end
-end
-
-function R:ProfileStop2(s)
-	if self.db.profile.enableProfiling then
-		stop2 = debugprofilestop()
-		R:Print(format(s, stop2 - start2))
-	end
-end
-
 function R:ProfileDebug(s)
-	if self.db.profile.enableProfiling then
 		R:Print(s)
 	end
 end

--- a/Core/Detection.lua
+++ b/Core/Detection.lua
@@ -145,8 +145,8 @@ end
 
 -- TODO: Does this really belong here? I don't think so...
 function R:BuildStatistics(reason)
-	self:ProfileStart2()
-	-- self:Debug("Building statistics table ("..reason..")")
+	self.Profiling:StartTimer("Collections.BuildStatistics." .. reason or "UnknownReason")
+	self:Debug("Building statistics table (" .. reason .. ")")
 
 	local tbl = {}
 	Rarity.lastStatCount = 0
@@ -173,7 +173,7 @@ function R:BuildStatistics(reason)
 		Rarity.lastStatCount = Rarity.lastStatCount + 1
 	end
 
-	self:ProfileStop2("BuildStatistics: %fms")
+	self.Profiling:EndTimer("Collections.BuildStatistics" .. reason or "UnknownReason")
 	return tbl
 end
 
@@ -182,8 +182,7 @@ function R:ScanStatistics(reason)
 		return
 	end -- Don't do this during combat as it has a tendency to run too long
 
-	self:ProfileStart2()
-	-- self:Debug("Scanning statistics ("..reason..")")
+	self.Profiling:StartTimer("Collections.ScanStatistics." .. reason or "UnknownReason")
 
 	if rarity_stats == nil or (Rarity.lastStatCount or 0) <= 0 then
 		self:Debug("Building initial statistics table")
@@ -276,5 +275,5 @@ function R:ScanStatistics(reason)
 		end
 	end
 
-	self:ProfileStop2("ScanStatistics: %fms")
+	self.Profiling:EndTimer("Collections.ScanStatistics" .. reason or "UnknownReason")
 end

--- a/Core/EventHandlers.lua
+++ b/Core/EventHandlers.lua
@@ -395,6 +395,8 @@ end
 -- This event also handles some special cases.
 -------------------------------------------------------------------------------------
 function R:OnCombat()
+	self.Profiling:StartTimer("EventHandlers.OnCombat")
+
 	-- Extract event payload (it's no longer being passed by the event iself as of 8.0.1)
 	local timestamp, eventType, hideCaster, srcGuid, srcName, srcFlags, srcRaidFlags, dstGuid, dstName, dstFlags, dstRaidFlags, spellId, spellName, spellSchool, auraType =
 		CombatLogGetCurrentEventInfo()
@@ -411,6 +413,7 @@ function R:OnCombat()
 				if not Rarity.guids[dstGuid] then
 					if not UnitAffectingCombat("player") and not UnitIsDead("player") then
 						Rarity:Debug("Ignoring this UNIT_DIED event because the player is alive, but not in combat")
+						self.Profiling:EndTimer("EventHandlers.OnCombat")
 						return
 					end
 
@@ -436,6 +439,7 @@ function R:OnCombat()
 			end
 		end
 	end
+	self.Profiling:EndTimer("EventHandlers.OnCombat")
 end
 
 local worldEventQuests = {
@@ -670,8 +674,18 @@ end
 -------------------------------------------------------------------------------------
 
 function R:OnMouseOver(event)
+	self.Profiling:StartTimer("EventHandlers.OnMouseOver")
+
 	local guid = UnitGUID("mouseover")
 	local npcid = self:GetNPCIDFromGUID(guid)
+
+	Rarity:Debug("OnMouseOver")
+	if not npcid then
+		self.Profiling:EndTimer("EventHandlers.OnMouseOver")
+
+		return
+	end
+	Rarity:Debug("UnitGUID: " .. tostring(npcid))
 
 	if npcid == 50409 or npcid == 50410 then
 		if not Rarity.guids[guid] then
@@ -687,6 +701,7 @@ function R:OnMouseOver(event)
 			end
 		end
 	end
+	self.Profiling:EndTimer("EventHandlers.OnMouseOver")
 end
 
 function R:OnProfileChanged(event, database, newProfileKey)
@@ -816,6 +831,8 @@ function R:OnSpellcastSent(event, unit, target, castGUID, spellID)
 	if unit ~= "player" then
 		return
 	end
+	self.Profiling:StartTimer("EventHandlers.OnSpellcastSent")
+
 	Rarity.foundTarget = false
 	-- ga = "No" -- WTF is this?
 
@@ -843,6 +860,8 @@ function R:OnSpellcastSent(event, unit, target, castGUID, spellID)
 	else
 		Rarity.previousSpell, Rarity.currentSpell = nil, nil
 	end
+
+	self.Profiling:EndTimer("EventHandlers.OnSpellcastSent")
 end
 
 function R:OnFishingEnded()
@@ -877,6 +896,7 @@ function R:OnCursorChanged(event)
 	if MinimapCluster:IsMouseOver() then
 		return
 	end
+	self.Profiling:StartTimer("EventHandlers.OnCursorChanged")
 	local t = stripColorCode(tooltipLeftText1:GetText())
 	if self.miningnodes[t] or self.fishnodes[t] or self.opennodes[t] then
 		Rarity.lastNode = t
@@ -885,6 +905,7 @@ function R:OnCursorChanged(event)
 	if Rarity.relevantSpells[Rarity.previousSpell] then
 		self:GetWorldTarget()
 	end
+	self.Profiling:EndTimer("EventHandlers.OnCursorChanged")
 end
 
 -- Doesn't really belong here, but no idea where to put it right now. Later...
@@ -895,6 +916,9 @@ function R:GetWorldTarget()
 	if MinimapCluster:IsMouseOver() then
 		return
 	end
+
+	self.Profiling:StartTimer("EventHandlers.GetWorldTarget")
+
 	local t = tooltipLeftText1:GetText()
 	Rarity:Debug("Getting world target " .. tostring(t))
 	if t and Rarity.previousSpell and t ~= Rarity.previousSpell and R.fishnodes[t] then
@@ -907,16 +931,22 @@ function R:GetWorldTarget()
 		Rarity.fishingTimer = self:ScheduleTimer(Rarity.OnFishingEnded, FISHING_DELAY)
 		Rarity.foundTarget = true
 	end
+
+	self.Profiling:EndTimer("EventHandlers.GetWorldTarget")
 end
 
 function R:OnSpellcastStopped(event, unit)
 	if unit ~= "player" then
 		return
 	end
+
+	self.Profiling:StartTimer("EventHandlers.OnSpellcastStopped")
+
 	if Rarity.relevantSpells[Rarity.previousSpell] then
 		self:GetWorldTarget()
 	end
 	Rarity.previousSpell, Rarity.currentSpell = Rarity.currentSpell, Rarity.currentSpell
+	self.Profiling:EndTimer("EventHandlers.OnSpellcastStopped")
 end
 
 function R:OnSpellcastFailed(event, unit)
@@ -992,10 +1022,14 @@ function R:ProcessContainerItems()
 end
 
 function R:ProcessInventoryItems()
+	self.Profiling:StartTimer("EventHandlers.ProcessInventoryItems")
+
 	for itemID, _ in pairs(Rarity.bagitems) do
 		self:ProcessCollectionItem(itemID)
 		self:ProcessOtherItem(itemID)
 	end
+
+	self.Profiling:EndTimer("EventHandlers.ProcessInventoryItems")
 end
 
 function R:ProcessCollectionItem(itemID)
@@ -1145,6 +1179,8 @@ function R:OnResearchArtifactComplete(event, _)
 end
 
 function R:OnEvent(event, ...)
+	self.Profiling:StartTimer("EventHandlers.OnEvent")
+
 	if event == "TRADE_SKILL_SHOW" then
 		Rarity.isTradeskillOpen = true
 	elseif event == "TRADE_SKILL_CLOSE" then
@@ -1169,6 +1205,8 @@ function R:OnEvent(event, ...)
 			Rarity.Session:End()
 		end
 	end
+
+	self.Profiling:EndTimer("EventHandlers.OnEvent")
 end
 
 -------------------------------------------------------------------------------------

--- a/Core/GUI/DataBrokerDisplay.lua
+++ b/Core/GUI/DataBrokerDisplay.lua
@@ -91,7 +91,7 @@ function GUI:UpdateText()
 		return
 	end
 
-	self:ProfileStart()
+	self.Profiling:StartTimer("GUI.UpdateText")
 	local attempts, dropChance, chance
 
 	local trackedItem = Rarity.Tracking:GetTrackedItem(1)
@@ -269,5 +269,5 @@ function GUI:UpdateText()
 			self.bar2:SetValue(chance, 100)
 		end
 	end
-	self:ProfileStop("UpdateText: %fms")
+	self.Profiling:EndTimer("GUI.UpdateText")
 end

--- a/Core/GUI/MainWindow.lua
+++ b/Core/GUI/MainWindow.lua
@@ -819,7 +819,7 @@ end
 local function addGroup(group, requiresGroup)
 	local trackedItem = Rarity.Tracking:GetTrackedItem()
 
-	R:ProfileStart2()
+	R.Profiling:StartTimer("GUI.MainWindow.AddGroup." .. group.name)
 
 	local addGroupStart = debugprofilestop()
 
@@ -1340,20 +1340,7 @@ local function addGroup(group, requiresGroup)
 
 	local addGroupEnd = debugprofilestop()
 
-	R:ProfileStop2(
-		"addGroup("
-			.. group.name
-			.. ", "
-			.. tostring(requiresGroup)
-			.. ") took %fms"
-			.. format(
-				" (Total: %f, Sort: %f, Iteration: %f, Tooltip: %f",
-				(addGroupEnd - addGroupStart),
-				(addGroupSortEnd - addGroupSortStart),
-				(addGroupIterationEnd - addGroupSortEnd),
-				(addGroupEnd - addGroupIterationEnd)
-			)
-	)
+	R.Profiling:EndTimer("GUI.MainWindow.AddGroup." .. group.name)
 
 	return added, itemsExistInThisGroup
 end
@@ -1411,6 +1398,8 @@ function R:ShowTooltip(hidden)
 		-- intentionally one column more than we need to avoid text clipping
 		tooltip:SetScale(self.db.profile.tooltipScale or 1)
 	end
+
+	self.Profiling:StartTimer("GUI.MainWindow.ShowTooltip")
 
 	table.wipe(headers)
 	local addedLast
@@ -1486,7 +1475,6 @@ function R:ShowTooltip(hidden)
 	tooltip:SetLineScript(line, "OnMouseUp", OnHeaderClicked)
 
 	-- Item groups
-	R:ProfileStart()
 
 	local somethingAdded = false
 
@@ -1598,21 +1586,6 @@ function R:ShowTooltip(hidden)
 		)
 	end
 
-	R:ProfileStop(
-		"Tooltip rendering took %fms"
-			.. format(
-				" (%f, %f, %f, %f, %f, %f, %f, %f)",
-				(group1end - group1start),
-				(group2end - group2start),
-				(group3end - group3start),
-				(group4end - group4start),
-				(group5end - group5start),
-				(group6end - group6start),
-				(group7end - group7start),
-				(group8end - group8start)
-			)
-	)
-
 	-- Footer
 	line = tooltip:AddLine()
 	tooltip:SetCell(line, 1, colorize(L["Click to toggle the progress bar"], gray), nil, nil, 3)
@@ -1632,6 +1605,9 @@ function R:ShowTooltip(hidden)
 			)
 		end
 	end
+
+	self.Profiling:EndTimer("GUI.MainWindow.ShowTooltip")
+
 	if hidden == true or Rarity.frame == nil then
 		renderingTip = false
 		return

--- a/Core/Tracking.lua
+++ b/Core/Tracking.lua
@@ -48,7 +48,7 @@ end
 function Tracking:Update(item)
 	self = Rarity
 	local trackedItem2 = Rarity.Tracking:GetTrackedItem(2)
-	self:ProfileStart2()
+	self.Profiling:StartTimer("Tracking.Update")
 	if not item or not item.itemId then
 		return
 	end
@@ -79,7 +79,7 @@ function Tracking:Update(item)
 	end
 	Rarity.GUI:UpdateText()
 	-- if self:InTooltip() then self:ShowTooltip() end
-	self:ProfileStop2("UpdateTrackedItem: %fms")
+	self.Profiling:EndTimer("Tracking.Update")
 end
 
 function Tracking:SetLastAttemptItem(item)


### PR DESCRIPTION
Same thing, but (with some overhead) can aggregate the results and inspect them more easily. I quickly put this together to get more data on the combat log event handling, so this could surely be refined. It's not that important, though.

(Also decoupled profiling output from the profiling setting to reduce spam if debug mode is disabled)

New hooks have been added for some event handlers as well; they don't seem to incur significant overhead, though.