### PR TITLE
Replace the luacheck CI setup with a curl command

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -10,29 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # LuaRocks needs the 5.1 headers to compile LuaCheck later, so we download them, too
-      - name: Install LuaJIT
-        run: sudo apt-get install luajit libluajit-5.1-dev
-
-      - name: Download LuaRocks
-        run: wget https://luarocks.org/releases/luarocks-3.7.0.tar.gz
-
-      - name: Unpack LuaRocks release
-        run: tar zxpf luarocks-3.7.0.tar.gz
-
-      - name: Install LuaRocks
-        run: cd luarocks-3.7.0 && ./configure && make && sudo make install
-
-      - name: Install LuaCheck
-        run: sudo luarocks install luacheck
-
-      # We don't want LuaCheck to analyze LuaRocks itself
-      # Ironically, it fails when doing that, but that's not useful here
-      - name: Change to temporary directory
-        run: mkdir temp && cd temp
-
       - name: Check out Git repository
         uses: actions/checkout@v4
 
+      - name: Install luacheck
+        run: |
+          curl https://github.com/lunarmodules/luacheck/releases/download/v1.2.0/luacheck -o luacheck --verbose --location
+          chmod +x luacheck
+
       - name: Perform static analysis
-        run: luacheck .
+        run: ./luacheck .


### PR DESCRIPTION
The workflow is currently broken because LuaRocks' package registry seems to serve a manifest that's too large for LuaJIT to process. There are various workarounds, the most obvious one being to replace LuaJIT with PUC's Lua interpreter. But the more I read about this problem, the more I'm convinced that I don't want to rely on the LuaRocks ecosystem for this particular task.