### PR TITLE
Merge the progress bar anchor and locked settings

### DIFF
--- a/Core/GUI/AnchoredTrackingBar.lua
+++ b/Core/GUI/AnchoredTrackingBar.lua
@@ -80,15 +80,13 @@ function GUI:UpdateBar()
 	else
 		self.barGroup:Show()
 	end
-	if not self.db.profile.bar.anchor then
-		self.barGroup:HideAnchor()
-	else
-		self.barGroup:ShowAnchor()
-	end
+
 	if not self.db.profile.bar.locked then
 		self.barGroup:Unlock()
+		self.barGroup:ShowAnchor()
 	else
 		self.barGroup:Lock()
+		self.barGroup:HideAnchor()
 	end
 end
 

--- a/Locales.lua
+++ b/Locales.lua
@@ -735,7 +735,6 @@ L["Progress Bar"] = true
 L["Width"] = true
 L["Height"] = true
 L["Scale"] = true
-L["Show anchor"] = true
 L["Locked"] = true
 L["Other Requirements"] = true
 L["Horde only"] = true

--- a/Modules/Options/Options.lua
+++ b/Modules/Options/Options.lua
@@ -998,19 +998,6 @@ function R:PrepareOptions()
 						order = newOrder(),
 						inline = true,
 						args = {
-							anchor = {
-								type = "toggle",
-								order = newOrder(),
-								name = L["Show anchor"],
-								get = function()
-									return self.db.profile.bar.anchor
-								end,
-								set = function(info, val)
-									self.db.profile.bar.anchor = val
-									Rarity.GUI:UpdateBar()
-									Rarity.GUI:UpdateText()
-								end,
-							},
 							locked = {
 								type = "toggle",
 								order = newOrder(),

--- a/Options_Defaults.lua
+++ b/Options_Defaults.lua
@@ -117,7 +117,6 @@ function R:PrepareDefaults()
 				height = 12,
 				scale = 1.0,
 				visible = false,
-				anchor = true,
 				locked = false,
 				texture = nil,
 				font = nil,


### PR DESCRIPTION
Displaying the anchor as a visual indicator of the bar's locked status works better if there's no way to toggle each individually. If someone cares only about seeing the anchor, leaving the bar unlocked shouldn't be much of an issue.

This also frees up some UI space for other settings related to the progress bar, although that's a secondary concern.